### PR TITLE
Add support for changing an application's locale

### DIFF
--- a/.changeset/polite-apricots-learn.md
+++ b/.changeset/polite-apricots-learn.md
@@ -1,0 +1,5 @@
+---
+"@open-pioneer/runtime": patch
+---
+
+The `resolveConfig` callback of an app's configuration can now inspect the application's `hostElement`.

--- a/.changeset/violet-carrots-turn.md
+++ b/.changeset/violet-carrots-turn.md
@@ -1,0 +1,16 @@
+---
+"@open-pioneer/runtime": patch
+---
+
+Add a builtin method on the `ApplicationContext` to change the application's locale.
+Note that with the current implementation, the application will simply restart with the new locale.
+The application's state will be lost.
+
+Example:
+
+```ts
+import { ApplicationContext } from "@open-pioneer/runtime";
+
+const appCtx: ApplicationContext = ...; // injected
+appCtx.setLocale("en-US");
+```

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -524,9 +524,6 @@ importers:
       '@open-pioneer/chakra-integration':
         specifier: workspace:^
         version: link:../../../packages/chakra-integration
-      '@open-pioneer/integration':
-        specifier: workspace:^
-        version: link:../../../packages/integration
       '@open-pioneer/runtime':
         specifier: workspace:^
         version: link:../../../packages/runtime

--- a/src/packages/runtime/CustomElement.test.ts
+++ b/src/packages/runtime/CustomElement.test.ts
@@ -532,6 +532,9 @@ describe("i18n support", function () {
     });
 
     it("supports restarting with a different locale", async () => {
+        // Hide i18n warnings
+        vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
         const spy = vi.spyOn(window.navigator, "languages", "get");
         spy.mockReturnValue(["en-US", "en"]);
 

--- a/src/packages/runtime/CustomElement.test.ts
+++ b/src/packages/runtime/CustomElement.test.ts
@@ -535,7 +535,11 @@ describe("i18n support", function () {
         const spy = vi.spyOn(window.navigator, "languages", "get");
         spy.mockReturnValue(["en-US", "en"]);
 
-        const api = await launchApp();
+        const api = await launchApp({
+            config: {
+                locale: "en-US"
+            }
+        });
         const { locale, message, supportedLocales } = await api.getLocaleInfo();
         expect(locale).toBe("en-US");
         expect(message).toBe("Hello world");
@@ -547,6 +551,7 @@ describe("i18n support", function () {
           ]
         `);
 
+        // Changes locale and has priority over the `config` above
         await api.setLocale("de-DE");
         await waitFor(async () => {
             const { locale } = await api.getLocaleInfo();

--- a/src/packages/runtime/api.ts
+++ b/src/packages/runtime/api.ts
@@ -43,6 +43,7 @@ export interface ApplicationContext extends DeclaredService<"runtime.Application
 
     /**
      * The current web component's shadow root.
+     * This shadow root is located inside the host element.
      */
     getShadowRoot(): ShadowRoot;
 
@@ -57,6 +58,16 @@ export interface ApplicationContext extends DeclaredService<"runtime.Application
      * E.g. `"de-DE"`
      */
     getLocale(): string;
+
+    /**
+     * Changes the application's locale.
+     * `locale` must be one of the supported locales, see {@link getSupportedLocales()} or `undefined` (for automatic locale).
+     * Note that `locale` does not need to be a precise match, e.g. `"de-DE"` is also valid if `"de"` is supported.
+     *
+     * > NOTE: This method will currently trigger a full restart of the application.
+     * > Altering the locale on the fly is possible in theory but has not been implemented yet.
+     */
+    setLocale(locale: string | undefined): void;
 
     /**
      * Returns the locales supported by the application, i.e.

--- a/src/packages/runtime/builtin-services/ApplicationContextImpl.ts
+++ b/src/packages/runtime/builtin-services/ApplicationContextImpl.ts
@@ -9,6 +9,9 @@ export interface ApplicationContextProperties {
     container: HTMLElement;
     locale: string;
     supportedLocales: string[];
+
+    /** A callback to change the application's locale is injected by the runtime. */
+    changeLocale(locale: string): void;
 }
 
 export class ApplicationContextImpl implements ApplicationContext {
@@ -17,6 +20,7 @@ export class ApplicationContextImpl implements ApplicationContext {
     #container: HTMLElement;
     #locale: string;
     #supportedLocales: readonly string[];
+    #changeLocale: (locale: string) => void;
 
     constructor(options: ServiceOptions, properties: ApplicationContextProperties) {
         this.#host = properties.host;
@@ -24,6 +28,7 @@ export class ApplicationContextImpl implements ApplicationContext {
         this.#container = properties.container;
         this.#locale = properties.locale;
         this.#supportedLocales = Object.freeze(Array.from(properties.supportedLocales));
+        this.#changeLocale = properties.changeLocale;
     }
 
     getHostElement(): HTMLElement {
@@ -40,6 +45,10 @@ export class ApplicationContextImpl implements ApplicationContext {
 
     getLocale(): string {
         return this.#locale;
+    }
+
+    setLocale(locale: string): void {
+        this.#changeLocale(locale);
     }
 
     getSupportedLocales(): readonly string[] {

--- a/src/packages/runtime/i18n.test.ts
+++ b/src/packages/runtime/i18n.test.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2023 Open Pioneer project (https://github.com/open-pioneer)
 // SPDX-License-Identifier: Apache-2.0
 import { expect, it } from "vitest";
-import { pickLocale } from "./i18n";
+import { I18nConfig } from "./i18n";
 
 it("picks a supported locale by default", () => {
     const appLocales = ["en", "de"];
@@ -52,3 +52,26 @@ it("throws if a locale cannot be forced", () => {
         `[Error: runtime:unsupported-locale: Locale 'de-simple' cannot be forced because it is not supported by the application. Supported locales are en, zh.]`
     );
 });
+
+it("computes whether a locale is supported", () => {
+    // Simple cases
+    expect(supportsLocale("en", ["en", "de"])).toBe(true);
+    expect(supportsLocale("de", ["en", "de"])).toBe(true);
+
+    // Fallback to plain language tag
+    expect(supportsLocale("de-DE", ["en", "de"])).toBe(true);
+
+    // Not supported at all
+    expect(supportsLocale("de", ["en"])).toBe(false);
+    expect(supportsLocale("de-DE", ["en"])).toBe(false);
+});
+
+function pickLocale(forcedLocale: string | undefined, appLocales: string[], userLocales: string[]) {
+    const config = new I18nConfig(appLocales);
+    return config.pickSupportedLocale(forcedLocale, userLocales);
+}
+
+function supportsLocale(testLocale: string, appLocales: string[]) {
+    const config = new I18nConfig(appLocales);
+    return config.supportsLocale(testLocale);
+}

--- a/src/packages/runtime/service-layer/PackageRepr.test.ts
+++ b/src/packages/runtime/service-layer/PackageRepr.test.ts
@@ -55,9 +55,12 @@ it("parses package metadata into internal package representations", function () 
 
     const testi18n: AppI18n = {
         locale: "test-locale",
-        supportedLocales: [],
+        supportedMessageLocales: [],
         createPackageI18n() {
             return createEmptyI18n("zh-CN");
+        },
+        supportsLocale() {
+            return true;
         }
     };
 

--- a/src/samples/i18n-sample/i18n-app/I18nUI.tsx
+++ b/src/samples/i18n-sample/i18n-app/I18nUI.tsx
@@ -12,7 +12,6 @@ import {
     VStack,
     Divider
 } from "@open-pioneer/chakra-integration";
-import { ExternalEventService } from "@open-pioneer/integration";
 import { useIntl, useService } from "open-pioneer:react-hooks";
 import { ReactNode } from "react";
 import { SamplePackageComponent } from "i18n-sample-package/SamplePackageComponent";
@@ -95,7 +94,7 @@ export function I18nUI() {
             </UnorderedList>
 
             <Center mb={4}>
-                <LocalePicker current={locale} locales={supportedLocales} />
+                <LocalePicker />
             </Center>
 
             <Divider my={4} />
@@ -109,23 +108,19 @@ export function I18nUI() {
     );
 }
 
-function LocalePicker(props: { current: string; locales: readonly string[] }) {
+function LocalePicker() {
+    const appCtx = useService<ApplicationContext>("runtime.ApplicationContext");
     const intl = useIntl();
-    const eventService = useService<ExternalEventService>("integration.ExternalEventService");
-    const changeLocale = (locale: string | undefined) => {
-        eventService.emitEvent("locale-changed", {
-            locale: locale
-        });
-    };
+    const locales = appCtx.getSupportedLocales();
 
     // One entry for every supported locale (to force it) and one empty
     // to pick the default behavior.
     const makeButton = (locale: string | undefined) => (
-        <Button key={locale ?? ""} onClick={() => changeLocale(locale)}>
+        <Button key={locale ?? ""} onClick={() => appCtx.setLocale(locale)}>
             {locale ?? intl.formatMessage({ id: "picker.default" })}
         </Button>
     );
-    const buttons: ReactNode[] = props.locales.map((locale) => makeButton(locale));
+    const buttons: ReactNode[] = locales.map((locale) => makeButton(locale));
     buttons.unshift(makeButton(undefined));
 
     return (

--- a/src/samples/i18n-sample/i18n-app/app.ts
+++ b/src/samples/i18n-sample/i18n-app/app.ts
@@ -6,14 +6,7 @@ import { I18nUI } from "./I18nUI";
 
 const Element = createCustomElement({
     component: I18nUI,
-    appMetadata,
-    async resolveConfig(ctx) {
-        const locale = ctx.getAttribute("forced-locale");
-        if (!locale) {
-            return undefined;
-        }
-        return { locale };
-    }
+    appMetadata
 });
 
 customElements.define("i18n-app", Element);

--- a/src/samples/i18n-sample/i18n-app/build.config.mjs
+++ b/src/samples/i18n-sample/i18n-app/build.config.mjs
@@ -5,6 +5,6 @@ import { defineBuildConfig } from "@open-pioneer/build-support";
 export default defineBuildConfig({
     i18n: ["de", "en", "de-simple"],
     ui: {
-        references: ["runtime.ApplicationContext", "integration.ExternalEventService"]
+        references: ["runtime.ApplicationContext"]
     }
 });

--- a/src/samples/i18n-sample/i18n-app/package.json
+++ b/src/samples/i18n-sample/i18n-app/package.json
@@ -4,7 +4,6 @@
     "private": true,
     "dependencies": {
         "@open-pioneer/runtime": "workspace:^",
-        "@open-pioneer/integration": "workspace:^",
         "@open-pioneer/chakra-integration": "workspace:^",
         "i18n-sample-package": "workspace:*"
     }

--- a/src/samples/i18n-sample/index.html
+++ b/src/samples/i18n-sample/index.html
@@ -6,42 +6,9 @@
         <title>I18n App Demo</title>
     </head>
     <body>
-        <div id="container"></div>
+        <div id="container">
+            <i18n-app></i18n-app>
+        </div>
     </body>
-    <script type="module">
-        import "./i18n-app/app.ts";
-
-        const container = document.getElementById("container");
-        restartApp(undefined);
-
-        /**
-         * Restarts the app in the given locale.
-         * The existing app (if any) will be removed from the container and will clean itself up.
-         *
-         * Locale can be undefined to use the app's default.
-         *
-         * The locale is transported by attaching it to the app node as an attribute.
-         * The attribute is in turn read by the app (in app.ts) in order to configure
-         * the framework.
-         */
-        function restartApp(locale) {
-            container.replaceChildren();
-            console.info(`Starting app with locale ${locale}`);
-
-            // (re-) create the app component
-            const app = document.createElement("i18n-app");
-            if (locale) {
-                app.setAttribute("forced-locale", locale);
-            }
-
-            // listen for selection event emitted from the react UI
-            // and recreate the app with the new locale
-            app.addEventListener("locale-changed", (event) => {
-                const newLocale = event.detail.locale;
-                restartApp(newLocale);
-            });
-
-            container.appendChild(app);
-        }
-    </script>
+    <script type="module" src="./i18n-app/app.ts"></script>
 </html>


### PR DESCRIPTION
This PR adds a new method to the `ApplicationContext` service provided by `@open-pioneer/runtime`. `applicationContext.setLocale(newLocale)` will restart the application with the specified locale.

Example:

```ts
import { ApplicationContext } from "@open-pioneer/runtime";

const appCtx: ApplicationContext = ...; // injected
appCtx.setLocale("en-US");
```