### PR TITLE
[intl] Support for rich text formatting (#86)

### DIFF
--- a/.changeset/calm-turkeys-smile.md
+++ b/.changeset/calm-turkeys-smile.md
@@ -10,6 +10,7 @@ _Example with react node as value:_
 
 ```tsx
 function Example() {
+    const intl = useIntl();
     // Given i18n message "Hello, {name}!"
     // replaces 'name' with the given react node:
     const message = intl.formatRichMessage(
@@ -26,6 +27,7 @@ _Example with basic formatting:_
 
 ```tsx
 function Example() {
+    const intl = useIntl();
     // Given i18n message "Hello, <strong>{name}</strong>!"
     // renders with actual <strong> html node:
     return <Box>{intl.formatRichMessage({ id: "foo" }, { name: "User" })}</Box>;
@@ -38,6 +40,7 @@ _Example with custom tag:_
 
 ```tsx
 function Example() {
+    const intl = useIntl();
     // Given i18n message "Open <foo>the door</foo>!",
     // renders 'foo' using the formatter function below:
     const message = intl.formatRichMessage(

--- a/.changeset/calm-turkeys-smile.md
+++ b/.changeset/calm-turkeys-smile.md
@@ -1,0 +1,51 @@
+---
+"@open-pioneer/runtime": minor
+---
+
+Add support for rich text formatting using the `intl` object.
+In addition to primitive values, rich text formatting supports react values and custom react tags.
+It always returns a react node, so can only be used in combination with react components.
+
+_Example with react node as value:_
+
+```tsx
+function Example() {
+    // Given i18n message "Hello, {name}!"
+    // replaces 'name' with the given react node:
+    const message = intl.formatRichMessage(
+        { id: "foo" },
+        {
+            name: <FancyUserName />
+        }
+    );
+    return <Box>{message}</Box>;
+}
+```
+
+_Example with basic formatting:_
+
+```tsx
+function Example() {
+    // Given i18n message "Hello, <strong>{name}</strong>!"
+    // renders with actual <strong> html node:
+    return <Box>{intl.formatRichMessage({ id: "foo" }, { name: "User" })}</Box>;
+}
+```
+
+Note that only a few basic formatting tags are predefined ("b", "strong", "i", "em", "code", "br").
+If you need more advanced tags, you can define your own, see below.
+_Example with custom tag:_
+
+```tsx
+function Example() {
+    // Given i18n message "Open <foo>the door</foo>!",
+    // renders 'foo' using the formatter function below:
+    const message = intl.formatRichMessage(
+        { id: "foo" },
+        {
+            foo: (parts) => <FancyTag>{parts}</FancyTag>
+        }
+    );
+    return <Box>{message}</Box>;
+}
+```

--- a/.changeset/calm-turkeys-smile.md
+++ b/.changeset/calm-turkeys-smile.md
@@ -52,3 +52,5 @@ function Example() {
     return <Box>{message}</Box>;
 }
 ```
+
+The TypeScript signature for the `intl.formatMessage()` function has been made a little bit stricter compared with FormatJS: only primitive values are allowed for the `values` argument (this should not affect users in practice).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -586,6 +586,9 @@ importers:
       '@open-pioneer/chakra-integration':
         specifier: workspace:^
         version: link:../chakra-integration
+      '@open-pioneer/runtime':
+        specifier: workspace:^
+        version: link:../runtime
       '@open-pioneer/runtime-react-support':
         specifier: workspace:^
         version: link:../runtime-react-support

--- a/src/packages/runtime-react-support/PackageContext.ts
+++ b/src/packages/runtime-react-support/PackageContext.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2023-2025 Open Pioneer project (https://github.com/open-pioneer)
 // SPDX-License-Identifier: Apache-2.0
 import { createContext } from "react";
-import type { PackageIntl } from "@open-pioneer/runtime/i18n";
+import type { PackageIntl } from "@open-pioneer/runtime";
 import type { Service } from "@open-pioneer/runtime/Service";
 import type { UseServiceOptions } from "@open-pioneer/runtime/react-integration/hooks";
 

--- a/src/packages/runtime/CustomElement.ts
+++ b/src/packages/runtime/CustomElement.ts
@@ -25,7 +25,7 @@ import {
     RUNTIME_AUTO_START
 } from "./builtin-services";
 import { ReferenceSpec } from "./service-layer/InterfaceSpec";
-import { AppI18n, createPackageIntl, getBrowserLocales, I18nConfig, initI18n } from "./i18n";
+import { AppIntl, createPackageIntl, getBrowserLocales, I18nConfig, initI18n } from "./i18n";
 import { ApplicationLifecycleEventService } from "./builtin-services/ApplicationLifecycleEventService";
 import { ErrorScreen, MESSAGES_BY_LOCALE } from "./ErrorScreen";
 const LOG = createLogger("runtime:CustomElement");
@@ -406,7 +406,7 @@ class ApplicationInstance {
     private initServiceLayer(config: {
         container: HTMLDivElement;
         properties: ApplicationProperties;
-        i18n: AppI18n;
+        i18n: AppIntl;
     }) {
         const { hostElement, shadowRoot, elementOptions, restart } = this.options;
         const { container, properties, i18n } = config;
@@ -509,7 +509,7 @@ function createServiceLayer(config: {
     packageMetadata: Record<string, PackageMetadata> | undefined;
     properties: ApplicationProperties;
     builtinPackage: PackageRepr;
-    i18n: AppI18n;
+    i18n: AppIntl;
 }) {
     const { packageMetadata, properties, builtinPackage, i18n } = config;
 

--- a/src/packages/runtime/build.config.mjs
+++ b/src/packages/runtime/build.config.mjs
@@ -7,7 +7,9 @@ export default defineBuildConfig({
         "index",
         // Needed for build plugin
         "metadata/index",
-        // Needed for react hooks and test utils
-        "react-integration/index"
+        // Needed for react hooks and @open-pioneer/test-utils
+        "react-integration/index",
+        // Needed for @open-pioneer/test-utils
+        "test-support/index"
     ]
 });

--- a/src/packages/runtime/builtin-services/index.ts
+++ b/src/packages/runtime/builtin-services/index.ts
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: 2023-2025 Open Pioneer project (https://github.com/open-pioneer)
 // SPDX-License-Identifier: Apache-2.0
-import { createEmptyI18n } from "../i18n";
+import { createEmptyPackageIntl } from "../i18n";
 import { PackageRepr } from "../service-layer/PackageRepr";
 import {
     createConstructorFactory,
@@ -34,7 +34,7 @@ export type BuiltinPackageProperties = ApplicationContextProperties;
  * The package produced here is always part of the application.
  */
 export function createBuiltinPackage(properties: BuiltinPackageProperties): PackageRepr {
-    const i18n = createEmptyI18n();
+    const i18n = createEmptyPackageIntl();
     const apiService = new ServiceRepr({
         name: "ApiServiceImpl",
         packageName: RUNTIME_PACKAGE_NAME,

--- a/src/packages/runtime/i18n/AppIntl.ts
+++ b/src/packages/runtime/i18n/AppIntl.ts
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: 2023-2025 Open Pioneer project (https://github.com/open-pioneer)
+// SPDX-License-Identifier: Apache-2.0
+import { createLogger, Error } from "@open-pioneer/core";
+import { ErrorId } from "../errors";
+import { ApplicationMetadata } from "../metadata";
+import { createPackageIntl, PackageIntl } from "./PackageIntl";
+import { getBrowserLocales, I18nConfig } from "./pick";
+const LOG = createLogger("runtime:i18n");
+
+/**
+ * Represents i18n info for the entire application.
+ * Currently not exposed to user code.
+ */
+export interface AppIntl {
+    /** Chosen locale */
+    readonly locale: string;
+
+    /** Supported locales from app metadata. */
+    readonly supportedMessageLocales: string[];
+
+    /** True if the locale can be used in this application (i.e. if there are any messages). */
+    supportsLocale(locale: string): boolean;
+
+    /** Given the package name, constructs a package i18n instance. */
+    createPackageI18n(packageName: string): PackageIntl;
+}
+
+/**
+ * Initializes the application's locale and fetches the appropriate i18n messages.
+ */
+export async function initI18n(
+    appMetadata: ApplicationMetadata | undefined,
+    forcedLocale: string | undefined
+): Promise<AppIntl> {
+    const messageLocales = appMetadata?.locales ?? [];
+    const userLocales = getBrowserLocales();
+    if (LOG.isDebug()) {
+        LOG.debug(
+            `Attempting to pick locale for user (locales: ${userLocales.join(
+                ", "
+            )}) from app (supported locales: ${messageLocales.join(
+                ", "
+            )}) [forcedLocale=${forcedLocale}].`
+        );
+    }
+
+    const i18nConfig = new I18nConfig(messageLocales);
+    const { locale, messageLocale } = i18nConfig.pickSupportedLocale(forcedLocale, userLocales);
+
+    if (LOG.isDebug()) {
+        LOG.debug(`Using locale '${locale}' with messages from locale '${messageLocale}'.`);
+    }
+
+    let messages: Record<string, Record<string, string>>;
+    if (messageLocales.includes(messageLocale)) {
+        try {
+            messages = (await appMetadata?.loadMessages?.(messageLocale)) ?? {};
+        } catch (e) {
+            throw new Error(
+                ErrorId.INTERNAL,
+                `Failed to load messages for locale '${messageLocale}'.`,
+                {
+                    cause: e
+                }
+            );
+        }
+    }
+    return {
+        locale,
+        supportedMessageLocales: messageLocales,
+        supportsLocale(locale) {
+            return i18nConfig.supportsLocale(locale);
+        },
+        createPackageI18n(packageName) {
+            const packageMessage = messages?.[packageName] ?? {};
+            return createPackageIntl(locale, packageMessage);
+        }
+    };
+}

--- a/src/packages/runtime/i18n/PackageIntl.test.tsx
+++ b/src/packages/runtime/i18n/PackageIntl.test.tsx
@@ -1,0 +1,110 @@
+// SPDX-FileCopyrightText: 2023-2025 Open Pioneer project (https://github.com/open-pioneer)
+// SPDX-License-Identifier: Apache-2.0
+import { Box, Tag } from "@open-pioneer/chakra-integration";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { createPackageIntl } from "./PackageIntl";
+
+describe("formatRichMessage", () => {
+    it("formats messages containing react nodes", async () => {
+        const intl = createPackageIntl("en-US", {
+            test: "Hello, {name}!"
+        });
+        const message = intl.formatRichMessage(
+            {
+                id: "test"
+            },
+            {
+                name: <Tag>User</Tag>
+            }
+        );
+        render(<Box data-testid="test">{message}</Box>);
+
+        const element = await screen.findByTestId("test");
+        expect(element).toMatchInlineSnapshot(`
+          <div
+            class="css-0"
+            data-testid="test"
+          >
+            Hello, 
+            <span
+              class="css-1qm7lvz"
+            >
+              User
+            </span>
+            !
+          </div>
+        `);
+    });
+
+    it("formats messages containing basic html tags", async () => {
+        const intl = createPackageIntl("en-US", {
+            test: "Hello, <strong>{name}</strong>!"
+        });
+        const message = intl.formatRichMessage(
+            {
+                id: "test"
+            },
+            {
+                name: "User"
+            }
+        );
+        render(<Box data-testid="test">{message}</Box>);
+
+        const element = await screen.findByTestId("test");
+        expect(element).toMatchInlineSnapshot(`
+          <div
+            class="css-0"
+            data-testid="test"
+          >
+            Hello, 
+            <strong>
+              User
+            </strong>
+            !
+          </div>
+        `);
+    });
+
+    it("supports defining custom tags", async () => {
+        const intl = createPackageIntl("en-US", {
+            test: "Hello, <custom1>Content of custom tag <custom2>and nested tag with {param}</custom2></custom1>!"
+        });
+        const message = intl.formatRichMessage(
+            {
+                id: "test"
+            },
+            {
+                custom1: (parts) => {
+                    return <Box className="from-custom-1">{parts}</Box>;
+                },
+                custom2: (parts) => {
+                    return <Box className="from-custom-2">{parts}</Box>;
+                },
+                param: "value from outside"
+            }
+        );
+        render(<Box data-testid="test">{message}</Box>);
+
+        const element = await screen.findByTestId("test");
+        expect(element).toMatchInlineSnapshot(`
+          <div
+            class="css-0"
+            data-testid="test"
+          >
+            Hello, 
+            <div
+              class="from-custom-1 css-0"
+            >
+              Content of custom tag 
+              <div
+                class="from-custom-2 css-0"
+              >
+                and nested tag with value from outside
+              </div>
+            </div>
+            !
+          </div>
+        `);
+    });
+});

--- a/src/packages/runtime/i18n/PackageIntl.test.tsx
+++ b/src/packages/runtime/i18n/PackageIntl.test.tsx
@@ -107,4 +107,28 @@ describe("formatRichMessage", () => {
           </div>
         `);
     });
+
+    it("generates a type error when using formatMessage with non-primitive types", async () => {
+        const intl = createPackageIntl("en-US", {
+            test: "Hello, {name}!"
+        });
+        const message = intl.formatMessage(
+            {
+                id: "test"
+            },
+            {
+                // @ts-expect-error Only primitive types are supported
+                name: {}
+            }
+        );
+
+        // This would need some postprocessing to work well in react, which is why formatRichMessage() exists.
+        expect(message).toMatchInlineSnapshot(`
+          [
+            "Hello, ",
+            {},
+            "!",
+          ]
+        `);
+    });
 });

--- a/src/packages/runtime/i18n/PackageIntl.ts
+++ b/src/packages/runtime/i18n/PackageIntl.ts
@@ -1,29 +1,192 @@
 // SPDX-FileCopyrightText: 2023-2025 Open Pioneer project (https://github.com/open-pioneer)
 // SPDX-License-Identifier: Apache-2.0
-import { createIntl, createIntlCache, IntlFormatters, IntlShape } from "@formatjs/intl";
+import {
+    createIntl,
+    createIntlCache,
+    IntlConfig,
+    IntlErrorCode,
+    IntlFormatters,
+    IntlShape,
+    MessageDescriptor,
+    OnErrorFn
+} from "@formatjs/intl";
+import {
+    type FormatXMLElementFn,
+    type Options as IntlMessageFormatOptions,
+    type PrimitiveType
+} from "intl-messageformat"; // not a dependency, this is a dependency of formatjs
+import { createElement, Fragment, ReactNode, Children } from "react";
+
+type BaseIntl = Pick<IntlShape, "locale" | "timeZone"> & IntlFormatters<string>;
 
 /**
  * Gives access to the package's i18n messages for the current locale.
  *
  * See also https://formatjs.io/docs/intl
  */
-export type PackageIntl = Pick<IntlShape, "locale" | "timeZone"> & IntlFormatters<string>;
+export type PackageIntl = BaseIntl & PackageIntlExtensions;
+
+/**
+ * Trails specific extensions to formatjs' intl API.
+ */
+export interface PackageIntlExtensions {
+    /**
+     * Similar to `formatMessage()`, but supports _rich text formatting_.
+     *
+     * React nodes are supported as input values, and custom tags can be implemented as react components.
+     * Note that the output is always a single react node.
+     *
+     * *Example with react node as value:*
+     *
+     * ```tsx
+     * function Example() {
+     *   // Given i18n message "Hello, {name}!"
+     *   // replaces 'name' with the given react node:
+     *   const message = intl.formatRichMessage({ id: "foo"}, {
+     *     name: <FancyUserName />
+     *   });
+     *   return <Box>{message}</Box>;
+     * }
+     * ```
+     *
+     * *Example with basic formatting:*
+     *
+     * ```tsx
+     * function Example() {
+     *   // Given i18n message "Hello, <strong>{name}</strong>!"
+     *   // renders with actual <strong> html node:
+     *   return <Box>{intl.formatRichMessage({ id: "foo"}, { name: "User" })}</Box>;
+     * }
+     * ```
+     *
+     * Note that only a few basic formatting tags are predefined ("b", "strong", "i", "em", "code", "br").
+     * If you need more advanced tags, you can define your own, see below.
+     *
+     * *Example with custom tag:*
+     *
+     * ```tsx
+     * function Example() {
+     *   // Given i18n message "Open <foo>the door</foo>!",
+     *   // renders 'foo' using the formatter function below:
+     *   const message = intl.formatRichMessage({ id: "foo"}, {
+     *     foo: (parts) => <FancyTag>{parts}</FancyTag>
+     *   });
+     *   return <Box>{message}</Box>;
+     * }
+     * ```
+     */
+    formatRichMessage: (
+        descriptor: MessageDescriptor,
+        values?: Record<string, RichTextValue>,
+        opts?: IntlMessageFormatOptions
+    ) => ReactNode;
+}
+
+/**
+ * Value types supported when rendering rich text messages.
+ * Primitive values (or single react nodes) are used for normal values.
+ * Functions are used to define how tags should be rendered.
+ *
+ * See {@link PackageIntlExtensions.formatRichMessage}
+ */
+export type RichTextValue = PrimitiveType | ReactNode | FormatXMLElementFn<ReactNode>;
 
 /**
  * Creates a package intl instance with the given locale and messages.
+ *
+ * @internal
  */
-export function createPackageIntl(locale: string, messages: Record<string, string>) {
+export function createPackageIntl(
+    locale: string,
+    messages: Record<string, string>,
+    options?: {
+        /** Used during testing to suppress console messages. */
+        suppressNotFoundError?: boolean;
+
+        /** Also used during testing */
+        defaultLocale?: string;
+    }
+): PackageIntl {
     const cache = createIntlCache();
-    return createIntl(
-        {
-            locale,
-            messages
-        },
-        cache
-    );
+    const config: IntlConfig = {
+        locale,
+        messages
+    };
+    if (options?.suppressNotFoundError) {
+        config.onError = ignoreMissingTranslationError;
+    }
+    if (options?.defaultLocale) {
+        config.defaultLocale = options.defaultLocale;
+    }
+
+    const intl = createIntl(config, cache) as unknown as PackageIntl;
+    intl.formatRichMessage = formatRichMessage.bind(undefined, intl);
+    return intl;
 }
 
 /** Creates an empty i18n instance, e.g. for tests. */
 export function createEmptyPackageIntl(locale = "en"): PackageIntl {
     return createPackageIntl(locale, {});
 }
+
+const RICH_TEXT_TAGS = Object.freeze({
+    "b": renderTag("b"),
+    "strong": renderTag("strong"),
+    "i": renderTag("i"),
+    "em": renderTag("em"),
+    "code": renderTag("code"),
+    "br": renderTag("br")
+});
+
+function formatRichMessage(
+    intl: PackageIntl,
+    descriptor: MessageDescriptor,
+    values: Record<string, RichTextValue> | undefined,
+    opts: IntlMessageFormatOptions | undefined
+): ReactNode {
+    values = {
+        ...RICH_TEXT_TAGS,
+        ...values
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const formatResult: any = intl.formatMessage(descriptor, preprocessValues(values) as any, opts);
+    return createElement(Fragment, undefined, ...formatResult);
+}
+
+function preprocessValues(values: Record<string, RichTextValue> | undefined) {
+    if (!values) {
+        return undefined;
+    }
+
+    const fixedValues: Record<string, RichTextValue> = {};
+    for (const [key, valueOrFn] of Object.entries(values)) {
+        let fixedValue = valueOrFn;
+        if (typeof valueOrFn === "function") {
+            fixedValue = (parts) => toKeyedChildren(valueOrFn(parts));
+        }
+        fixedValues[key] = fixedValue;
+    }
+    return fixedValues;
+}
+
+function renderTag(tag: string): FormatXMLElementFn<ReactNode> {
+    return function renderRichTag(parts) {
+        return createElement(tag, undefined, ...parts);
+    };
+}
+
+// Seems to be necessary to avoid "Each child in a list should have a unique "key" prop." error
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function toKeyedChildren(children: any) {
+    return Children.toArray(children);
+}
+
+/** Hides missing translation errors during tests */
+const ignoreMissingTranslationError: OnErrorFn = (err) => {
+    if (err.code === IntlErrorCode.MISSING_TRANSLATION) {
+        return;
+    }
+
+    console.error(err);
+};

--- a/src/packages/runtime/i18n/PackageIntl.ts
+++ b/src/packages/runtime/i18n/PackageIntl.ts
@@ -40,6 +40,7 @@ export interface PackageIntlExtensions {
      *
      * ```tsx
      * function Example() {
+     *   const intl = useIntl();
      *   // Given i18n message "Hello, {name}!"
      *   // replaces 'name' with the given react node:
      *   const message = intl.formatRichMessage({ id: "foo"}, {
@@ -53,6 +54,7 @@ export interface PackageIntlExtensions {
      *
      * ```tsx
      * function Example() {
+     *   const intl = useIntl();
      *   // Given i18n message "Hello, <strong>{name}</strong>!"
      *   // renders with actual <strong> html node:
      *   return <Box>{intl.formatRichMessage({ id: "foo"}, { name: "User" })}</Box>;
@@ -66,6 +68,7 @@ export interface PackageIntlExtensions {
      *
      * ```tsx
      * function Example() {
+     *   const intl = useIntl();
      *   // Given i18n message "Open <foo>the door</foo>!",
      *   // renders 'foo' using the formatter function below:
      *   const message = intl.formatRichMessage({ id: "foo"}, {

--- a/src/packages/runtime/i18n/PackageIntl.ts
+++ b/src/packages/runtime/i18n/PackageIntl.ts
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2023-2025 Open Pioneer project (https://github.com/open-pioneer)
+// SPDX-License-Identifier: Apache-2.0
+import { createIntl, createIntlCache, IntlFormatters, IntlShape } from "@formatjs/intl";
+
+/**
+ * Gives access to the package's i18n messages for the current locale.
+ *
+ * See also https://formatjs.io/docs/intl
+ */
+export type PackageIntl = Pick<IntlShape, "locale" | "timeZone"> & IntlFormatters<string>;
+
+/**
+ * Creates a package intl instance with the given locale and messages.
+ */
+export function createPackageIntl(locale: string, messages: Record<string, string>) {
+    const cache = createIntlCache();
+    return createIntl(
+        {
+            locale,
+            messages
+        },
+        cache
+    );
+}
+
+/** Creates an empty i18n instance, e.g. for tests. */
+export function createEmptyPackageIntl(locale = "en"): PackageIntl {
+    return createPackageIntl(locale, {});
+}

--- a/src/packages/runtime/i18n/PackageIntl.ts
+++ b/src/packages/runtime/i18n/PackageIntl.ts
@@ -17,7 +17,8 @@ import {
 } from "intl-messageformat"; // not a dependency, this is a dependency of formatjs
 import { createElement, Fragment, ReactNode, Children } from "react";
 
-type BaseIntl = Pick<IntlShape, "locale" | "timeZone"> & IntlFormatters<string>;
+type BaseIntl = Pick<IntlShape, "locale" | "timeZone"> &
+    Omit<IntlFormatters<string>, "formatMessage">;
 
 /**
  * Gives access to the package's i18n messages for the current locale.
@@ -27,9 +28,28 @@ type BaseIntl = Pick<IntlShape, "locale" | "timeZone"> & IntlFormatters<string>;
 export type PackageIntl = BaseIntl & PackageIntlExtensions;
 
 /**
- * Trails specific extensions to formatjs' intl API.
+ * Trails specific extensions to FormatJS' intl API.
  */
 export interface PackageIntlExtensions {
+    /**
+     * Formats a message with the given descriptor and values.
+     *
+     * This is a method directly implemented by FormatJS see
+     * - [Documentation](<https://formatjs.github.io/docs/intl/#formatmessage>)
+     * - {@link IntlShape.formatMessage | Base Implementation}
+     *
+     * The typings here make the signature a little bit stricter: only primitive values
+     * are allowed for formatting.
+     *
+     * If you need rich text (react) formatting, see {@link PackageIntlExtensions.formatRichMessage}.
+     */
+    formatMessage(
+        this: void,
+        descriptor: MessageDescriptor,
+        values?: Record<string, PrimitiveType | FormatXMLElementFn<string, string>>,
+        opts?: IntlMessageFormatOptions
+    ): string;
+
     /**
      * Similar to `formatMessage()`, but supports _rich text formatting_.
      *

--- a/src/packages/runtime/i18n/index.ts
+++ b/src/packages/runtime/i18n/index.ts
@@ -1,5 +1,11 @@
 // SPDX-FileCopyrightText: 2023-2025 Open Pioneer project (https://github.com/open-pioneer)
 // SPDX-License-Identifier: Apache-2.0
 export { type AppIntl, initI18n } from "./AppIntl";
-export { type PackageIntl, createPackageIntl, createEmptyPackageIntl } from "./PackageIntl";
+export {
+    type PackageIntl,
+    type PackageIntlExtensions,
+    type RichTextValue,
+    createPackageIntl,
+    createEmptyPackageIntl
+} from "./PackageIntl";
 export { type LocalePickResult, I18nConfig, getBrowserLocales } from "./pick";

--- a/src/packages/runtime/i18n/index.ts
+++ b/src/packages/runtime/i18n/index.ts
@@ -1,0 +1,5 @@
+// SPDX-FileCopyrightText: 2023-2025 Open Pioneer project (https://github.com/open-pioneer)
+// SPDX-License-Identifier: Apache-2.0
+export { type AppIntl, initI18n } from "./AppIntl";
+export { type PackageIntl, createPackageIntl, createEmptyPackageIntl } from "./PackageIntl";
+export { type LocalePickResult, I18nConfig, getBrowserLocales } from "./pick";

--- a/src/packages/runtime/i18n/pick.test.ts
+++ b/src/packages/runtime/i18n/pick.test.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2023-2025 Open Pioneer project (https://github.com/open-pioneer)
 // SPDX-License-Identifier: Apache-2.0
 import { expect, it } from "vitest";
-import { I18nConfig } from "./i18n";
+import { I18nConfig } from "./pick";
 
 it("picks a supported locale by default", () => {
     const appLocales = ["en", "de"];

--- a/src/packages/runtime/i18n/pick.ts
+++ b/src/packages/runtime/i18n/pick.ts
@@ -1,104 +1,8 @@
 // SPDX-FileCopyrightText: 2023-2025 Open Pioneer project (https://github.com/open-pioneer)
 // SPDX-License-Identifier: Apache-2.0
-import { createIntl, createIntlCache, IntlFormatters, IntlShape } from "@formatjs/intl";
-import { ErrorId } from "./errors";
 import { createLogger, Error } from "@open-pioneer/core";
-import { ApplicationMetadata } from "./metadata";
+import { ErrorId } from "../errors";
 const LOG = createLogger("runtime:i18n");
-
-/**
- * Represents i18n info for the entire application.
- * Currently not exposed to user code.
- */
-export interface AppI18n {
-    /** Chosen locale */
-    readonly locale: string;
-
-    /** Supported locales from app metadata. */
-    readonly supportedMessageLocales: string[];
-
-    /** True if the locale can be used in this application (i.e. if there are any messages). */
-    supportsLocale(locale: string): boolean;
-
-    /** Given the package name, constructs a package i18n instance. */
-    createPackageI18n(packageName: string): PackageIntl;
-}
-
-/**
- * Gives access to the package's i18n messages for the current locale.
- *
- * See also https://formatjs.io/docs/intl
- */
-export type PackageIntl = Pick<IntlShape, "locale" | "timeZone"> & IntlFormatters<string>;
-
-export function createPackageIntl(locale: string, messages: Record<string, string>) {
-    const cache = createIntlCache();
-    return createIntl(
-        {
-            locale,
-            messages
-        },
-        cache
-    );
-}
-
-/**
- * Initializes the application's locale and fetches the appropriate i18n messages.
- */
-export async function initI18n(
-    appMetadata: ApplicationMetadata | undefined,
-    forcedLocale: string | undefined
-): Promise<AppI18n> {
-    const messageLocales = appMetadata?.locales ?? [];
-    const userLocales = getBrowserLocales();
-    if (LOG.isDebug()) {
-        LOG.debug(
-            `Attempting to pick locale for user (locales: ${userLocales.join(
-                ", "
-            )}) from app (supported locales: ${messageLocales.join(
-                ", "
-            )}) [forcedLocale=${forcedLocale}].`
-        );
-    }
-
-    const i18nConfig = new I18nConfig(messageLocales);
-    const { locale, messageLocale } = i18nConfig.pickSupportedLocale(forcedLocale, userLocales);
-
-    if (LOG.isDebug()) {
-        LOG.debug(`Using locale '${locale}' with messages from locale '${messageLocale}'.`);
-    }
-
-    let messages: Record<string, Record<string, string>>;
-    if (messageLocales.includes(messageLocale)) {
-        try {
-            messages = (await appMetadata?.loadMessages?.(messageLocale)) ?? {};
-        } catch (e) {
-            throw new Error(
-                ErrorId.INTERNAL,
-                `Failed to load messages for locale '${messageLocale}'.`,
-                {
-                    cause: e
-                }
-            );
-        }
-    }
-    return {
-        locale,
-        supportedMessageLocales: messageLocales,
-        supportsLocale(locale) {
-            return i18nConfig.supportsLocale(locale);
-        },
-        createPackageI18n(packageName) {
-            const packageMessage = messages?.[packageName] ?? {};
-            return createPackageIntl(locale, packageMessage);
-        }
-    };
-}
-
-/** Creates an empty i18n instance, e.g. for tests. */
-export function createEmptyI18n(locale = "en"): PackageIntl {
-    return createPackageIntl(locale, {});
-}
 
 export interface LocalePickResult {
     /**
@@ -113,7 +17,7 @@ export interface LocalePickResult {
 }
 
 /**
- * Picks a locale for the app. Exported for tests.
+ * Picks a locale for the app.
  */
 export class I18nConfig {
     private appLocales: string[];

--- a/src/packages/runtime/index.ts
+++ b/src/packages/runtime/index.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2023-2025 Open Pioneer project (https://github.com/open-pioneer)
 // SPDX-License-Identifier: Apache-2.0
 export * from "./api";
-export { type PackageIntl } from "./i18n";
+export { type PackageIntl, type PackageIntlExtensions, type RichTextValue } from "./i18n";
 export {
     type ApplicationElement,
     type ApplicationElementConstructor,

--- a/src/packages/runtime/react-integration/ReactIntegration.test.ts
+++ b/src/packages/runtime/react-integration/ReactIntegration.test.ts
@@ -10,7 +10,7 @@ import { beforeEach, expect, it, afterEach, vi, describe } from "vitest";
 import { Service, ServiceConstructor } from "../Service";
 import { usePropertiesInternal, useServiceInternal, useServicesInternal } from "./hooks";
 import { useTheme } from "@open-pioneer/chakra-integration";
-import { PackageIntl, createEmptyI18n } from "../i18n";
+import { PackageIntl, createEmptyPackageIntl } from "../i18n";
 import { InterfaceSpec, ReferenceSpec } from "../service-layer/InterfaceSpec";
 import { PackageRepr } from "../service-layer/PackageRepr";
 import { ServiceLayer } from "../service-layer/ServiceLayer";
@@ -420,7 +420,7 @@ function createIntegration(options?: {
 }): TestIntegration {
     const wrapper = document.createElement("div");
     const packages = new Map<string, PackageRepr>();
-    const i18n = options?.i18n ?? createEmptyI18n();
+    const i18n = options?.i18n ?? createEmptyPackageIntl();
     if (!options?.disablePackage) {
         const packageName = options?.packageName ?? "test";
         const services =

--- a/src/packages/runtime/service-layer/PackageRepr.test.ts
+++ b/src/packages/runtime/service-layer/PackageRepr.test.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2023-2025 Open Pioneer project (https://github.com/open-pioneer)
 // SPDX-License-Identifier: Apache-2.0
 import { expect, it } from "vitest";
-import { AppI18n, createEmptyI18n, PackageIntl } from "../i18n";
+import { AppIntl, createEmptyPackageIntl, PackageIntl } from "../i18n";
 import { PackageMetadata } from "../metadata";
 import { expectError } from "../test-utils/expectError";
 import { createPackages, PackageRepr } from "./PackageRepr";
@@ -53,11 +53,11 @@ it("parses package metadata into internal package representations", function () 
         }
     };
 
-    const testi18n: AppI18n = {
+    const testi18n: AppIntl = {
         locale: "test-locale",
         supportedMessageLocales: [],
         createPackageI18n() {
-            return createEmptyI18n("zh-CN");
+            return createEmptyPackageIntl("zh-CN");
         },
         supportsLocale() {
             return true;
@@ -232,5 +232,5 @@ function createPackageFromMetadata(
     properties?: Record<string, unknown>,
     i18n?: PackageIntl
 ) {
-    return PackageRepr.create(data, i18n ?? createEmptyI18n(), properties);
+    return PackageRepr.create(data, i18n ?? createEmptyPackageIntl(), properties);
 }

--- a/src/packages/runtime/service-layer/PackageRepr.ts
+++ b/src/packages/runtime/service-layer/PackageRepr.ts
@@ -3,7 +3,7 @@
 import { Error } from "@open-pioneer/core";
 import { ApplicationProperties } from "../CustomElement";
 import { ErrorId } from "../errors";
-import { PackageIntl, AppI18n } from "../i18n";
+import { PackageIntl, AppIntl } from "../i18n";
 import { PackageMetadata, PropertyMetadata } from "../metadata";
 import { parseReferenceSpec, ReferenceSpec } from "./InterfaceSpec";
 import { ServiceRepr } from "./ServiceRepr";
@@ -77,7 +77,7 @@ export class PackageRepr {
 
 export function createPackages(
     packages: Record<string, PackageMetadata>,
-    i18n: AppI18n,
+    i18n: AppIntl,
     customProperties?: ApplicationProperties
 ) {
     return Object.entries(packages).map<PackageRepr>(([name, packageMetadata]) => {

--- a/src/packages/runtime/service-layer/ServiceLayer.test.ts
+++ b/src/packages/runtime/service-layer/ServiceLayer.test.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2023-2025 Open Pioneer project (https://github.com/open-pioneer)
 // SPDX-License-Identifier: Apache-2.0
 import { expect, it } from "vitest";
-import { createEmptyI18n } from "../i18n";
+import { createEmptyPackageIntl } from "../i18n";
 import { Service, ServiceOptions } from "../Service";
 import { PackageRepr, PackageReprOptions } from "./PackageRepr";
 import { ServiceLayer } from "./ServiceLayer";
@@ -447,7 +447,7 @@ function createService(options: Partial<ServiceReprOptions>) {
         name: "test-service",
         packageName: "test-package",
         factory: createConstructorFactory(class {}),
-        intl: createEmptyI18n(),
+        intl: createEmptyPackageIntl(),
         ...options
     });
 }
@@ -455,7 +455,7 @@ function createService(options: Partial<ServiceReprOptions>) {
 function createPackage(options: Partial<PackageReprOptions>) {
     return new PackageRepr({
         name: "test-package",
-        intl: createEmptyI18n(),
+        intl: createEmptyPackageIntl(),
         ...options
     });
 }

--- a/src/packages/runtime/service-layer/verifyDependencies.test.ts
+++ b/src/packages/runtime/service-layer/verifyDependencies.test.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2023-2025 Open Pioneer project (https://github.com/open-pioneer)
 // SPDX-License-Identifier: Apache-2.0
 import { assert, expect, it } from "vitest";
-import { createEmptyI18n } from "../i18n";
+import { createEmptyPackageIntl } from "../i18n";
 import { expectError } from "../test-utils/expectError";
 import { InterfaceSpec, ReferenceSpec } from "./InterfaceSpec";
 import { ReadonlyServiceLookup } from "./ServiceLookup";
@@ -406,7 +406,7 @@ function mockServices(data: ServiceData[]): ServiceRepr[] {
             name,
             packageName,
             factory: createConstructorFactory(clazz),
-            intl: createEmptyI18n(),
+            intl: createEmptyPackageIntl(),
             dependencies,
             interfaces
         });

--- a/src/packages/runtime/test-support/index.ts
+++ b/src/packages/runtime/test-support/index.ts
@@ -1,0 +1,5 @@
+// SPDX-FileCopyrightText: 2023-2025 Open Pioneer project (https://github.com/open-pioneer)
+// SPDX-License-Identifier: Apache-2.0
+
+// Imported from @open-pioneer/test-utils
+export { createPackageIntl } from "../i18n";

--- a/src/packages/test-utils/package.json
+++ b/src/packages/test-utils/package.json
@@ -16,6 +16,7 @@
         "build": "build-pioneer-package"
     },
     "dependencies": {
+        "@open-pioneer/runtime": "workspace:^",
         "@open-pioneer/runtime-react-support": "workspace:^",
         "@testing-library/react": "catalog:",
         "react": "catalog:",

--- a/src/packages/test-utils/vanilla.ts
+++ b/src/packages/test-utils/vanilla.ts
@@ -1,12 +1,7 @@
 // SPDX-FileCopyrightText: 2023-2025 Open Pioneer project (https://github.com/open-pioneer)
 // SPDX-License-Identifier: Apache-2.0
-import {
-    createIntlCache,
-    createIntl as createFormatJsIntl,
-    IntlErrorCode,
-    OnErrorFn
-} from "@formatjs/intl";
 import { PackageIntl } from "@open-pioneer/runtime";
+import { createPackageIntl } from "@open-pioneer/runtime/test-support";
 
 /** Options for `createIntl`. */
 export interface I18nOptions {
@@ -49,24 +44,8 @@ export function createIntl(options?: I18nOptions): PackageIntl {
     const messages = options?.messages ?? {};
     const locale = options?.locale ?? "en";
     const defaultMessageLocale = options?.defaultMessageLocale ?? "en";
-    const cache = createIntlCache();
-    const intl = createFormatJsIntl(
-        {
-            locale,
-            defaultLocale: defaultMessageLocale,
-            messages,
-            onError: INTL_ERROR_HANDLER
-        },
-        cache
-    );
-    return intl;
+    return createPackageIntl(locale, messages, {
+        defaultLocale: defaultMessageLocale,
+        suppressNotFoundError: true
+    });
 }
-
-/** Hides missing translation errors during tests */
-const INTL_ERROR_HANDLER: OnErrorFn = (err) => {
-    if (err.code === IntlErrorCode.MISSING_TRANSLATION) {
-        return;
-    }
-
-    console.error(err);
-};

--- a/src/samples/i18n-howto/app/AppUI.tsx
+++ b/src/samples/i18n-howto/app/AppUI.tsx
@@ -1,20 +1,22 @@
 // SPDX-FileCopyrightText: 2023-2025 Open Pioneer project (https://github.com/open-pioneer)
 // SPDX-License-Identifier: Apache-2.0
 import {
+    Box,
     Container,
     Heading,
-    Text,
     Input,
-    Box,
-    Stack,
-    StackDivider,
-    RadioGroup,
-    Radio,
+    NumberDecrementStepper,
+    NumberIncrementStepper,
     NumberInput,
     NumberInputField,
     NumberInputStepper,
-    NumberIncrementStepper,
-    NumberDecrementStepper
+    Radio,
+    RadioGroup,
+    Stack,
+    StackDivider,
+    Tag,
+    Text,
+    VStack
 } from "@open-pioneer/chakra-integration";
 import { useIntl } from "open-pioneer:react-hooks";
 import { useState } from "react";
@@ -55,6 +57,9 @@ function ExampleStack() {
             </Box>
             <Box bg="white" w="100%" p={4} color="black" borderWidth="1px" borderColor="black">
                 <DateTimeFormatExample></DateTimeFormatExample>
+            </Box>
+            <Box bg="white" w="100%" p={4} color="black" borderWidth="1px" borderColor="black">
+                <RichTextExample></RichTextExample>
             </Box>
         </Stack>
     );
@@ -218,6 +223,47 @@ function DateTimeFormatExample() {
                     style: "long"
                 })}
             </Text>
+        </>
+    );
+}
+
+function RichTextExample() {
+    const intl = useIntl();
+
+    return (
+        <>
+            <Heading as="h4" size="md">
+                {intl.formatMessage({ id: "richtext.heading" })}
+            </Heading>
+            <VStack spacing={2} align="start">
+                <Box>
+                    {intl.formatRichMessage(
+                        { id: "richtext.messageWithReactNode" },
+                        {
+                            element: <Tag>Hi</Tag>
+                        }
+                    )}
+                </Box>
+                <Box>
+                    {intl.formatRichMessage({
+                        id: "richtext.messageWithInlineCode"
+                    })}
+                </Box>
+                <Box>
+                    {intl.formatRichMessage(
+                        {
+                            id: "richtext.messageWithReactTag"
+                        },
+                        {
+                            customTag: (parts) => (
+                                <Box display="inline-block" background="trails.200">
+                                    {parts}
+                                </Box>
+                            )
+                        }
+                    )}
+                </Box>
+            </VStack>
         </>
     );
 }

--- a/src/samples/i18n-howto/app/app.ts
+++ b/src/samples/i18n-howto/app/app.ts
@@ -4,15 +4,14 @@ import { createCustomElement } from "@open-pioneer/runtime";
 import * as appMetadata from "open-pioneer:app";
 import { AppUI } from "./AppUI";
 
+const URL_PARAMS = new URLSearchParams(window.location.search);
+const FORCED_LANG = URL_PARAMS.get("lang") || undefined;
+
 const Element = createCustomElement({
     component: AppUI,
     appMetadata,
-    async resolveConfig(ctx) {
-        const locale = ctx.getAttribute("forced-locale");
-        if (!locale) {
-            return undefined;
-        }
-        return { locale };
+    config: {
+        locale: FORCED_LANG
     }
 });
 

--- a/src/samples/i18n-howto/app/i18n/de.yaml
+++ b/src/samples/i18n-howto/app/i18n/de.yaml
@@ -28,3 +28,8 @@ messages:
     heading: Beispiel DateTimeFormat
     timelabel: "Der gewählte Zeitpunkt ist "
     relativetimelabel: "Relative Zeit zum gewählten Zeitpunkt: "
+  richtext:
+    heading: Beispiel für Rich Text
+    messageWithReactNode: "Dieser Text enthält (hier: {element}) ein beliebiges React-Element."
+    messageWithInlineCode: "Dieser Text enthält <code>inline code</code>."
+    messageWithReactTag: "Dieser Text verwendet <customTag>einen Tag, der über React-Elemente definiert ist.</customTag>"

--- a/src/samples/i18n-howto/app/i18n/en.yaml
+++ b/src/samples/i18n-howto/app/i18n/en.yaml
@@ -28,3 +28,8 @@ messages:
     heading: DateTimeFormat Examples
     timelabel: "the chosen time is "
     relativetimelabel: "relative time to chosen time: "
+  richtext:
+    heading: Example For Rich Text
+    messageWithReactNode: "This text contains (here: {element}) an arbitrary React element."
+    messageWithInlineCode: "This text contains <code>inline code</code>."
+    messageWithReactTag: "This text uses <customTag>a tag defined via React elements.</customTag>"

--- a/src/samples/i18n-howto/index.html
+++ b/src/samples/i18n-howto/index.html
@@ -6,23 +6,9 @@
         <title>Empty Site</title>
     </head>
     <body>
-        <div id="container"></div>
-        <script type="module">
-            import "./app/app.ts";
-
-            const container = document.getElementById("container");
-            initApp();
-
-            function initApp() {
-                const queryString = window.location.search;
-                const urlParams = new URLSearchParams(queryString);
-                const lang = urlParams.get("lang");
-                const app = document.createElement("i18n-howto");
-                if (lang) {
-                    app.setAttribute("forced-locale", lang);
-                }
-                container.appendChild(app);
-            }
-        </script>
+        <div id="container">
+            <i18n-howto></i18n-howto>
+        </div>
+        <script type="module" src="./app/app.ts"></script>
     </body>
 </html>


### PR DESCRIPTION
Issue: #86 

Add support for rich text formatting using the `intl` object.
In addition to primitive values, rich text formatting supports react values and custom react tags.
It always returns a react node, so can only be used in combination with react components.

_Example with react node as value:_

```tsx
function Example() {
    const intl = useIntl();
    // Given i18n message "Hello, {name}!"
    // replaces 'name' with the given react node:
    const message = intl.formatRichMessage(
        { id: "foo" },
        {
            name: <FancyUserName />
        }
    );
    return <Box>{message}</Box>;
}
```

_Example with basic formatting:_

```tsx
function Example() {
    const intl = useIntl();
    // Given i18n message "Hello, <strong>{name}</strong>!"
    // renders with actual <strong> html node:
    return <Box>{intl.formatRichMessage({ id: "foo" }, { name: "User" })}</Box>;
}
```

Note that only a few basic formatting tags are predefined ("b", "strong", "i", "em", "code", "br").
If you need more advanced tags, you can define your own, see below.
_Example with custom tag:_

```tsx
function Example() {
    const intl = useIntl();
    // Given i18n message "Open <foo>the door</foo>!",
    // renders 'foo' using the formatter function below:
    const message = intl.formatRichMessage(
        { id: "foo" },
        {
            foo: (parts) => <FancyTag>{parts}</FancyTag>
        }
    );
    return <Box>{message}</Box>;
}
```
