### PR TITLE
Support configuration of login/logout options

### DIFF
--- a/.changeset/huge-showers-do.md
+++ b/.changeset/huge-showers-do.md
@@ -1,0 +1,47 @@
+---
+"@open-pioneer/authentication-keycloak": minor
+---
+
+Support configuration of keycloak's login options and logout options.
+
+For example, to redirect to a different site after logout:
+
+```ts
+// app.ts
+const element = createCustomElement({
+    component: AppUI,
+    appMetadata,
+    config: {
+        properties: {
+            "@open-pioneer/authentication-keycloak": {
+                keycloakOptions: {
+                    // ...
+                    keycloakLogoutOptions: {
+                        redirectUri: "https://example.com"
+                    }
+                }
+            } satisfies KeycloakProperties
+        },
+        locale: FORCED_LANG
+    }
+});
+```
+
+The plugin also supports options for the `logout` method to supply dynamic logout options:
+
+```ts
+// via auth service
+const authService = ...;
+authService.logout({
+    // These are passed directly the keycloak plugin (if it is being used).
+    pluginOptions: {
+        redirectUri: "https://example.com",
+    }
+})
+
+// via direct reference to the plugin ("authentication-keycloak.KeycloakAuthPlugin")
+const keycloakAuthPlugin = ...;
+keycloakAuthPlugin.logout({
+    redirectUri: "https://example.com",
+});
+```

--- a/.changeset/icy-tips-unite.md
+++ b/.changeset/icy-tips-unite.md
@@ -1,0 +1,17 @@
+---
+"@open-pioneer/authentication": minor
+---
+
+New `options` parameter for the `logout` method of `AuthService`.
+
+This will allow you to pass custom options that may be supported by the active authentication plugin.
+
+```ts
+const authService = ...; // injected
+authService.logout({
+    // Interpretation of this parameter highly depends on the active authentication plugin.
+    pluginOptions: {
+        redirectUri: "https://example.com"
+    }
+})
+```

--- a/.changeset/rotten-rabbits-post.md
+++ b/.changeset/rotten-rabbits-post.md
@@ -1,0 +1,11 @@
+---
+"@open-pioneer/authentication-keycloak": minor
+---
+
+Make `RefreshOptions` optional with sensible default values.
+
+- `autoRefresh`: true
+- `interval` (for token lifetime checks): 10 seconds
+- `timeLeft`: 60 seconds (minimum required lifetime during token validity checks)
+
+These values are used when they are not explicitly configured using package properties.

--- a/src/packages/authentication-keycloak/KeycloakAuthPluginImpl.test.ts
+++ b/src/packages/authentication-keycloak/KeycloakAuthPluginImpl.test.ts
@@ -1,19 +1,23 @@
 // SPDX-FileCopyrightText: 2023-2025 Open Pioneer project (https://github.com/open-pioneer)
 // SPDX-License-Identifier: Apache-2.0
 import { afterEach, beforeEach, it, vi, expect, MockInstance } from "vitest";
-import { KeycloakAuthPlugin } from "./KeycloakAuthPlugin";
+import { KeycloakAuthPluginImpl } from "./KeycloakAuthPluginImpl";
 import { createService } from "@open-pioneer/test-utils/services";
 import { NotificationService, NotificationOptions } from "@open-pioneer/notifier";
+import { KeycloakLoginOptions, KeycloakLogoutOptions } from "keycloak-js";
 
 //https://vitest.dev/api/vi.html#vi-mock
 const hoisted = vi.hoisted(() => {
     return {
         keycloakMock: {
             init: vi.fn(),
-            updateToken: vi.fn()
+            updateToken: vi.fn(),
+            login: vi.fn(),
+            logout: vi.fn()
         }
     };
 });
+
 //The call to vi.mock is hoisted
 vi.mock("keycloak-js", () => ({
     default: vi.fn().mockReturnValue(hoisted.keycloakMock)
@@ -121,7 +125,7 @@ it("should reject by updating the token", async () => {
 it("should update the token in interval", async () => {
     hoisted.keycloakMock.init.mockResolvedValue(true);
     hoisted.keycloakMock.updateToken.mockResolvedValue(true);
-    const refreshSpy = vi.spyOn(KeycloakAuthPlugin.prototype as any, "__refresh");
+    const refreshSpy = vi.spyOn(KeycloakAuthPluginImpl.prototype as any, "__refresh");
     const { keycloakAuthPlugin } = await setup();
     restoreMocks.push(refreshSpy);
 
@@ -132,9 +136,98 @@ it("should update the token in interval", async () => {
     expect(hoisted.keycloakMock.updateToken).toHaveBeenCalledTimes(1);
 });
 
+it("should call login with correct options", async () => {
+    hoisted.keycloakMock.init.mockResolvedValue(false);
+
+    const loginOptions = {
+        redirectUri: "https://example.com/callback"
+    };
+    const { keycloakAuthPlugin } = await setup({ loginOptions });
+    await vi.waitUntil(() => keycloakAuthPlugin.getAuthState().kind === "not-authenticated");
+
+    const loginBehavior = keycloakAuthPlugin.getLoginBehavior();
+    if (loginBehavior.kind === "effect") {
+        loginBehavior.login();
+    } else {
+        throw new Error("Unexpected login behavior kind");
+    }
+
+    expect(hoisted.keycloakMock.login).toHaveBeenCalledWith(loginOptions);
+});
+
+it("should call login with default options when no custom options provided", async () => {
+    hoisted.keycloakMock.init.mockResolvedValue(false);
+
+    const { keycloakAuthPlugin } = await setup();
+    await vi.waitUntil(() => keycloakAuthPlugin.getAuthState().kind === "not-authenticated");
+
+    const loginBehavior = keycloakAuthPlugin.getLoginBehavior();
+    if (loginBehavior.kind === "effect") {
+        loginBehavior.login();
+    } else {
+        throw new Error("Unexpected login behavior kind");
+    }
+
+    expect(hoisted.keycloakMock.login).toHaveBeenCalledWith({
+        redirectUri: undefined
+    });
+});
+
+it("should call logout with correct options", async () => {
+    hoisted.keycloakMock.init.mockResolvedValue(true);
+    const logoutOptions = {
+        redirectUri: "https://example.com/logout"
+    };
+
+    const { keycloakAuthPlugin } = await setup({ logoutOptions });
+    await vi.waitUntil(() => keycloakAuthPlugin.getAuthState().kind === "authenticated");
+
+    keycloakAuthPlugin.logout();
+
+    expect(hoisted.keycloakMock.logout).toHaveBeenCalledWith(logoutOptions);
+});
+
+it("should call logout with default options when no custom options provided", async () => {
+    hoisted.keycloakMock.init.mockResolvedValue(true);
+
+    const { keycloakAuthPlugin } = await setup();
+    await vi.waitUntil(() => keycloakAuthPlugin.getAuthState().kind === "authenticated");
+
+    keycloakAuthPlugin.logout();
+
+    expect(hoisted.keycloakMock.logout).toHaveBeenCalledWith({
+        redirectUri: undefined
+    });
+});
+
+it("should call logout with merged options when additional options are provided", async () => {
+    hoisted.keycloakMock.init.mockResolvedValue(true);
+
+    const { keycloakAuthPlugin } = await setup({
+        logoutOptions: {
+            redirectUri: "https://example.com/logout"
+        }
+    });
+    await vi.waitUntil(() => keycloakAuthPlugin.getAuthState().kind === "authenticated");
+
+    keycloakAuthPlugin.logout({
+        logoutMethod: "POST"
+    });
+
+    expect(hoisted.keycloakMock.logout).toHaveBeenCalledWith({
+        redirectUri: "https://example.com/logout",
+        logoutMethod: "POST"
+    });
+});
+
 type MockedNotifier = Partial<NotificationService> & { _notifications: NotificationOptions[] };
 
-async function setup() {
+interface SetupOptions {
+    loginOptions?: KeycloakLoginOptions;
+    logoutOptions?: KeycloakLogoutOptions;
+}
+
+async function setup(options: SetupOptions = {}) {
     const notifier = {
         _notifications: [] as NotificationOptions[],
 
@@ -142,7 +235,7 @@ async function setup() {
             this._notifications.push(options);
         }
     } satisfies MockedNotifier;
-    const keycloakAuthPlugin = await createService(KeycloakAuthPlugin, {
+    const keycloakAuthPlugin = await createService(KeycloakAuthPluginImpl, {
         properties: {
             keycloakOptions: {
                 refreshOptions: {
@@ -160,8 +253,8 @@ async function setup() {
                     realm: "realm",
                     clientId: "test-id"
                 },
-                keycloakLogoutOptions: null,
-                keycloakLoginOptions: null
+                keycloakLogoutOptions: options.logoutOptions ?? null,
+                keycloakLoginOptions: options.loginOptions ?? null
             }
         },
         references: {

--- a/src/packages/authentication-keycloak/README.md
+++ b/src/packages/authentication-keycloak/README.md
@@ -46,13 +46,20 @@ export function AppUI() {
 To configure the `authentication-keycloak` package, adjust these properties.
 For more details on the configuration properties, visit the [API Reference](https://www.keycloak.org/docs/latest/securing_apps/index.html#api-reference).
 
-| Property            |        Type         |                                                                                                           Description |                                             Default |
-| ------------------- | :-----------------: | --------------------------------------------------------------------------------------------------------------------: | --------------------------------------------------: |
-| refreshOptions      |   RefreshOptions    |                            Configure token refresh behavior and manage access token lifecycle in client applications. | `{autoRefresh: true, interval: 6000, timeLeft: 70}` |
-| keycloakInitOptions | KeycloakInitOptions |                                               Configure Keycloak's behavior during client application initialization. |         `{onLoad: "check-sso", pkceMethod: "S256"}` |
-| keycloakConfig      |   KeycloakConfig    | The configuration settings required to establish a connection between the client application and the Keycloak server. |                                                     |
+| Property              | Type                  |                                                                                                           Description |                                              Default |
+| --------------------- | --------------------- | --------------------------------------------------------------------------------------------------------------------: | ---------------------------------------------------: |
+| keycloakConfig        | KeycloakConfig        | The configuration settings required to establish a connection between the client application and the Keycloak server. |                                                      |
+| refreshOptions        | RefreshOptions        |                            Configure token refresh behavior and manage access token lifecycle in client applications. | `{autoRefresh: true, interval: 10000, timeLeft: 60}` |
+| keycloakInitOptions   | KeycloakInitOptions   |                                               Configure Keycloak's behavior during client application initialization. |          `{onLoad: "check-sso", pkceMethod: "S256"}` |
+| keycloakLoginOptions  | KeycloakLoginOptions  |                                                                 Configure Keycloak login options (e.g. redirect URI). |                                                      |
+| keycloakLogoutOptions | KeycloakLogoutOptions |                                                                Configure Keycloak logout options (e.g. redirect URI). |                                                      |
 
 ```ts
+interface KeycloakConfig {
+    url: string;
+    realm: string;
+    clientId: string;
+}
 interface RefreshOptions {
     autoRefresh: boolean;
     interval: number;
@@ -62,11 +69,6 @@ interface KeycloakInitOptions {
     onLoad: string;
     pkceMethod: string;
     scope: string;
-}
-interface KeycloakConfig {
-    url: string;
-    realm: string;
-    clientId: string;
 }
 ```
 
@@ -86,21 +88,31 @@ const element = createCustomElement({
         properties: {
             "@open-pioneer/authentication-keycloak": {
                 keycloakOptions: {
+                    keycloakConfig: {
+                        url: "http://keycloak-server/base_path",
+                        realm: "myrealm",
+                        clientId: "myapp"
+                    },
+                    // optional
                     refreshOptions: {
                         autoRefresh: true,
-                        interval: 6000,
-                        timeLeft: 70
+                        interval: 10000,
+                        timeLeft: 60
                     },
+                    // optional
                     keycloakInitOptions: {
                         onLoad: "check-sso",
                         pkceMethod: "S256"
                         // additional configuration, for example:
                         // scope: "openid address phone"
                     },
-                    keycloakConfig: {
-                        url: "http://keycloak-server/base_path",
-                        realm: "myrealm",
-                        clientId: "myapp"
+                    // optional
+                    keycloakLoginOptions: {
+                        // ...
+                    },
+                    // optional
+                    keycloakLogoutOptions: {
+                        redirectUri: "https://example.com" // where to redirect after logout
                     }
                 }
             } satisfies KeycloakProperties // for auto completion / validation

--- a/src/packages/authentication-keycloak/api.ts
+++ b/src/packages/authentication-keycloak/api.ts
@@ -1,6 +1,13 @@
 // SPDX-FileCopyrightText: 2023-2025 Open Pioneer project (https://github.com/open-pioneer)
 // SPDX-License-Identifier: Apache-2.0
-import type { KeycloakConfig, KeycloakInitOptions } from "keycloak-js";
+import { AuthPlugin } from "@open-pioneer/authentication";
+import { DECLARE_SERVICE_INTERFACE } from "@open-pioneer/runtime";
+import type {
+    KeycloakConfig,
+    KeycloakInitOptions,
+    KeycloakLoginOptions,
+    KeycloakLogoutOptions
+} from "keycloak-js";
 
 /**
  * The central configuration properties of the plugin.
@@ -17,29 +24,41 @@ export interface KeycloakProperties {
 export interface KeycloakOptions {
     /**
      * The configuration details for connecting to Keycloak.
-     * 'url': The URL of your Keycloak server.
-     * 'realm': The realm within Keycloak.
-     * 'clientId': The ID of the client application registered in Keycloak.
+     *
+     * - 'url': The URL of your Keycloak server.
+     * - 'realm': The realm within Keycloak.
+     * - 'clientId': The ID of the client application registered in Keycloak.
      */
     keycloakConfig: KeycloakConfig;
 
     /**
      * Control the automatic refreshing of authentication tokens.
-     * 'autoRefresh': Whether token refreshing should happen automatically.
-     * 'interval': The interval (in milliseconds) at which token refreshing should occur.
-     * 'timeLeft': The remaining time (in milliseconds) before token expiration.
+     *
+     * - 'autoRefresh': Whether token refreshing should happen automatically.
+     * - 'interval': The interval (in milliseconds) at which token refreshing should occur.
+     * - 'timeLeft': The remaining time (in milliseconds) before token expiration.
      */
-    refreshOptions: RefreshOptions;
+    refreshOptions?: RefreshOptions;
 
     /**
      * Define how Keycloak initializes.
-     * This properties can be used:
-     * 'onLoad': Specifies when Keycloak should initialize.
-     * 'pkceMethod': The method used for PKCE for enhanced security.
-     * 'scope': The scope of the authentication.
      *
+     * These properties can be used:
+     * - 'onLoad': Specifies when Keycloak should initialize. Default: `check-sso`.
+     * - 'pkceMethod': The method used for PKCE for enhanced security. Default: `S256`.
+     * - 'scope': The scope of the authentication.
      */
-    keycloakInitOptions: Partial<KeycloakInitOptions>;
+    keycloakInitOptions?: Partial<KeycloakInitOptions>;
+
+    /**
+     * Define behavior when the user logs in.
+     */
+    keycloakLoginOptions?: Partial<KeycloakLoginOptions>;
+
+    /**
+     * Define behavior when the user logs out.
+     */
+    keycloakLogoutOptions?: Partial<KeycloakLogoutOptions>;
 }
 
 /**
@@ -48,14 +67,38 @@ export interface KeycloakOptions {
 export interface RefreshOptions {
     /**
      * Whether token refreshing should happen automatically.
+     *
+     * Default: true.
      */
-    autoRefresh: boolean;
+    autoRefresh?: boolean;
+
     /**
-     * The interval (in milliseconds) at which token refreshing should occur.
+     * The interval (in milliseconds) at which tokens are checked for validity.
+     * If the token's remaining lifetime is too short (see {@link timeLeft}), then the token is refreshed.
+     *
+     * Default: 10000 milliseconds.
      */
-    interval: number;
+    interval?: number;
+
     /**
-     * The remaining time (in milliseconds) before token expiration.
+     * The minimum required lifetime during token validity checks.
+     * Tokens that expire within `timeLeft` are refreshed.
+     *
+     * Default: 60 seconds.
      */
-    timeLeft: number;
+    timeLeft?: number;
+}
+
+/**
+ * The interface implemented by the Keycloak authentication plugin.
+ */
+export interface KeycloakAuthPlugin extends AuthPlugin {
+    readonly [DECLARE_SERVICE_INTERFACE]?: "authentication-keycloak.KeycloakAuthPlugin";
+
+    /**
+     * Explicitly triggers a logout.
+     *
+     * `options` used here can override the package properties used by the plugin.
+     */
+    logout(options?: Partial<KeycloakLogoutOptions>): void;
 }

--- a/src/packages/authentication-keycloak/build.config.mjs
+++ b/src/packages/authentication-keycloak/build.config.mjs
@@ -11,7 +11,7 @@ export default defineBuildConfig({
                 // The generic interface, used by the AuthService
                 "authentication.AuthPlugin",
 
-                // Concrete interface for this plugin (note: no additional API yet).
+                // Specific interface for this plugin.
                 "authentication-keycloak.KeycloakAuthPlugin"
             ],
             references: {

--- a/src/packages/authentication-keycloak/getKeycloakConfig.test.ts
+++ b/src/packages/authentication-keycloak/getKeycloakConfig.test.ts
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: 2023-2025 Open Pioneer project (https://github.com/open-pioneer)
 // SPDX-License-Identifier: Apache-2.0
-import { it, expect } from "vitest";
-import { getKeycloakConfig } from "./KeycloakAuthPlugin";
+import { expect, it } from "vitest";
 import { KeycloakOptions } from "./api";
+import { getKeycloakConfig } from "./getKeycloakConfig";
 
 it("expect to throw an error if the keycloakConfig not provided ", async () => {
     const keycloakOptions = {
@@ -24,4 +24,91 @@ it("expect to throw an error if the keycloakConfig not provided ", async () => {
     expect(() => getKeycloakConfig(properties)).toThrowErrorMatchingInlineSnapshot(
         `[Error: KeycloakConfig not found: The Keycloak configuration options are required by the plugin to perform login and logout operations]`
     );
+});
+
+it("expect default values are used for refreshOptions", () => {
+    const keycloakOptions = {
+        keycloakConfig: {
+            url: "https://keycloak.example.com",
+            realm: "example-realm",
+            clientId: "example-client"
+        }
+    } as KeycloakOptions;
+
+    const properties = {
+        keycloakOptions
+    };
+    const config = getKeycloakConfig(properties);
+    expect(config.refreshOptions).toEqual({
+        autoRefresh: true,
+        interval: 10000,
+        timeLeft: 60
+    });
+});
+
+it("expect default values for refreshOptions are overridden", () => {
+    const keycloakOptions = {
+        keycloakConfig: {
+            url: "https://keycloak.example.com",
+            realm: "example-realm",
+            clientId: "example-client"
+        },
+        refreshOptions: {
+            autoRefresh: false,
+            interval: 5000,
+            timeLeft: 30
+        }
+    } as KeycloakOptions;
+
+    const properties = {
+        keycloakOptions
+    };
+    const config = getKeycloakConfig(properties);
+    expect(config.refreshOptions).toEqual({
+        autoRefresh: false,
+        interval: 5000,
+        timeLeft: 30
+    });
+});
+
+it("expect values for login options can be changed", () => {
+    const keycloakOptions = {
+        keycloakConfig: {
+            url: "https://keycloak.example.com",
+            realm: "example-realm",
+            clientId: "example-client"
+        },
+        keycloakLoginOptions: {
+            redirectUri: "https://example.com/login-callback"
+        }
+    } as KeycloakOptions;
+
+    const properties = {
+        keycloakOptions
+    };
+    const config = getKeycloakConfig(properties);
+    expect(config.loginOptions).toEqual({
+        redirectUri: "https://example.com/login-callback"
+    });
+});
+
+it("expect values for logoutOptions can be changed", () => {
+    const keycloakOptions = {
+        keycloakConfig: {
+            url: "https://keycloak.example.com",
+            realm: "example-realm",
+            clientId: "example-client"
+        },
+        keycloakLogoutOptions: {
+            redirectUri: "https://example.com/logout-callback"
+        }
+    } as KeycloakOptions;
+
+    const properties = {
+        keycloakOptions
+    };
+    const config = getKeycloakConfig(properties);
+    expect(config.logoutOptions).toEqual({
+        redirectUri: "https://example.com/logout-callback"
+    });
 });

--- a/src/packages/authentication-keycloak/getKeycloakConfig.ts
+++ b/src/packages/authentication-keycloak/getKeycloakConfig.ts
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: 2023-2025 Open Pioneer project (https://github.com/open-pioneer)
+// SPDX-License-Identifier: Apache-2.0
+import type {
+    KeycloakConfig,
+    KeycloakInitOptions,
+    KeycloakLoginOptions,
+    KeycloakLogoutOptions
+} from "keycloak-js";
+import type { KeycloakProperties, RefreshOptions } from "./api";
+import { createLogger } from "@open-pioneer/core";
+const LOG = createLogger("authentication-keycloak:getKeycloakConfig");
+
+const DEFAULT_REFRESH_OPTS = {
+    autoRefresh: true,
+    interval: 10000,
+    timeLeft: 60
+} as const;
+
+const DEFAULT_INIT_OPTS = {
+    onLoad: "check-sso",
+    pkceMethod: "S256"
+} as const;
+
+export type ResolvedRefreshOptions = Required<RefreshOptions>;
+
+export interface ResolvedKeycloakOptions {
+    config: KeycloakConfig;
+    initOptions: KeycloakInitOptions;
+    refreshOptions: ResolvedRefreshOptions;
+    loginOptions: Partial<KeycloakLoginOptions>;
+    logoutOptions: Partial<KeycloakLogoutOptions>;
+}
+
+/**
+ * Parses the user supplied package properties.
+ */
+export function getKeycloakConfig(
+    properties: Partial<KeycloakProperties>
+): ResolvedKeycloakOptions {
+    const { keycloakOptions } = properties;
+    const {
+        refreshOptions,
+        keycloakInitOptions,
+        keycloakConfig,
+        keycloakLoginOptions,
+        keycloakLogoutOptions
+    } = keycloakOptions!;
+    return {
+        config: getConfig(keycloakConfig),
+        refreshOptions: getRefreshOptions(refreshOptions),
+        initOptions: getInitOptions(keycloakInitOptions),
+        loginOptions: getLoginOptions(keycloakLoginOptions),
+        logoutOptions: getLogoutOptions(keycloakLogoutOptions)
+    };
+}
+
+function getConfig(keycloakConfig: KeycloakConfig | undefined): KeycloakConfig {
+    if (!keycloakConfig || isObjectEmpty(keycloakConfig)) {
+        throw new Error(
+            `KeycloakConfig not found: The Keycloak configuration options are required by the plugin to perform login and logout operations`
+        );
+    }
+    return { ...keycloakConfig };
+}
+
+function getRefreshOptions(refreshOptions: RefreshOptions | undefined): ResolvedRefreshOptions {
+    if (!refreshOptions || isObjectEmpty(refreshOptions)) {
+        LOG.info(`Using default options for keycloak token refresh`, DEFAULT_REFRESH_OPTS);
+    }
+    return {
+        ...DEFAULT_REFRESH_OPTS,
+        ...refreshOptions
+    };
+}
+
+function getInitOptions(keycloakInitOptions: KeycloakInitOptions | undefined): KeycloakInitOptions {
+    if (!keycloakInitOptions || isObjectEmpty(keycloakInitOptions)) {
+        LOG.info(`Using default options for keycloak init`, DEFAULT_INIT_OPTS);
+    }
+    return {
+        ...DEFAULT_INIT_OPTS,
+        ...keycloakInitOptions
+    };
+}
+
+function getLoginOptions(
+    keycloakLoginOptions: Partial<KeycloakLoginOptions> | undefined
+): Partial<KeycloakLoginOptions> {
+    return {
+        redirectUri: undefined, // backwards-compat; unsure if needed
+        ...keycloakLoginOptions
+    };
+}
+
+function getLogoutOptions(
+    keycloakLogoutOptions: Partial<KeycloakLogoutOptions> | undefined
+): Partial<KeycloakLogoutOptions> {
+    return {
+        redirectUri: undefined, // backwards-compat; unsure if needed
+        ...keycloakLogoutOptions
+    };
+}
+
+const isObjectEmpty = (objectName: unknown) => {
+    return objectName && Object.keys(objectName).length === 0 && objectName.constructor === Object;
+};

--- a/src/packages/authentication-keycloak/services.ts
+++ b/src/packages/authentication-keycloak/services.ts
@@ -1,3 +1,3 @@
 // SPDX-FileCopyrightText: 2023-2025 Open Pioneer project (https://github.com/open-pioneer)
 // SPDX-License-Identifier: Apache-2.0
-export { KeycloakAuthPlugin } from "./KeycloakAuthPlugin";
+export { KeycloakAuthPluginImpl as KeycloakAuthPlugin } from "./KeycloakAuthPluginImpl";

--- a/src/packages/authentication/AuthServiceImpl.ts
+++ b/src/packages/authentication/AuthServiceImpl.ts
@@ -8,7 +8,14 @@ import {
     destroyResource,
     createLogger
 } from "@open-pioneer/core";
-import type { AuthPlugin, AuthService, AuthState, LoginBehavior, SessionInfo } from "./api";
+import type {
+    AuthPlugin,
+    AuthService,
+    AuthState,
+    LoginBehavior,
+    LogoutOptions,
+    SessionInfo
+} from "./api";
 import type { Service, ServiceOptions } from "@open-pioneer/runtime";
 import { syncWatch } from "@conterra/reactivity-core";
 
@@ -62,9 +69,9 @@ export class AuthServiceImpl implements AuthService, Service {
         return this.#plugin.getLoginBehavior();
     }
 
-    logout(): void {
-        LOG.debug("Triggering logout");
-        this.#plugin.logout();
+    logout(options?: LogoutOptions): void {
+        LOG.debug("Triggering logout with options", options);
+        this.#plugin.logout(options?.pluginOptions);
     }
 
     #onPluginStateChanged(newState: AuthState) {

--- a/src/packages/authentication/api.ts
+++ b/src/packages/authentication/api.ts
@@ -93,6 +93,16 @@ export interface LoginEffect {
 }
 
 /**
+ * Options that can be passed to the {@link AuthService.logout} method.
+ */
+export interface LogoutOptions {
+    /**
+     * Custom options that will be passed directly to the currently active {@link AuthPlugin}.
+     */
+    pluginOptions?: unknown;
+}
+
+/**
  * Manages the current user's authentication state.
  *
  * The current state (such as session info) can be retrieved and watched for changes.
@@ -125,7 +135,7 @@ export interface AuthService extends DeclaredService<"authentication.AuthService
     /**
      * Terminates the current session (if any).
      */
-    logout(): void;
+    logout(options?: LogoutOptions): void;
 }
 
 /**
@@ -155,6 +165,10 @@ export interface AuthPlugin extends DeclaredService<"authentication.AuthPlugin">
      *
      * Should result in a new state (including a `changed` event) if the user
      * was authenticated.
+     *
+     * @param options Custom options that may be supported by the plugin.
+     * The optional `pluginOptions` in {@link AuthService.logout} will be passed to this parameter.
+     * This parameter is not typed at this point (but should be in the plugin's actual implementation).
      */
-    logout(): Promise<void> | void;
+    logout(options?: unknown): Promise<void> | void;
 }


### PR DESCRIPTION
See issue #78 

----

Excerpt from changeset:

Support configuration of keycloak's login options and logout options.

For example, to redirect to a different site after logout:

```ts
// app.ts
const element = createCustomElement({
    component: AppUI,
    appMetadata,
    config: {
        properties: {
            "@open-pioneer/authentication-keycloak": {
                keycloakOptions: {
                    // ...
                    keycloakLogoutOptions: {
                        redirectUri: "https://example.com"
                    }
                }
            } satisfies KeycloakProperties
        },
        locale: FORCED_LANG
    }
});
```

The plugin also supports options for the `logout` method to supply dynamic logout options:

```ts
// via auth service
const authService = ...;
authService.logout({
    // These are passed directly the keycloak plugin (if it is being used).
    pluginOptions: {
        redirectUri: "https://example.com",
    }
})

// via direct reference to the plugin ("authentication-keycloak.KeycloakAuthPlugin")
const keycloakAuthPlugin = ...;
keycloakAuthPlugin.logout({
    redirectUri: "https://example.com",
});
```