### PR TITLE
[runtime] Expose `overrides` in `resolveConfig()`

### DIFF
--- a/.changeset/gold-guests-dig.md
+++ b/.changeset/gold-guests-dig.md
@@ -1,0 +1,5 @@
+---
+"@open-pioneer/runtime": minor
+---
+
+Expose `overrides` in `resolveConfig()` hook when the application restarts.

--- a/src/packages/runtime/CustomElement.ts
+++ b/src/packages/runtime/CustomElement.ts
@@ -4,7 +4,7 @@ import { SystemConfig as ChakraSystemConfig } from "@chakra-ui/react";
 import { createLogger, Error } from "@open-pioneer/core";
 import { ComponentType } from "react";
 import { ApiMethods, type ApiExtension } from "./api";
-import { AppInstance, AppOverrides } from "./app";
+import { AppInstance } from "./app";
 import { ErrorId } from "./errors";
 import { ApplicationMetadata } from "./metadata";
 
@@ -67,9 +67,26 @@ export interface ConfigContext {
     hostElement: HTMLElement;
 
     /**
+     * Defined when the application forcefully restarts with new options.
+     */
+    overrides: ApplicationOverrides | undefined;
+
+    /**
      * Returns an attribute from the application's root node.
      */
     getAttribute(name: string): string | undefined;
+}
+
+/**
+ * Application overrides are defined when the is explicitly being restarted with new options.
+ *
+ * Options set through overrides cannot be overwritten by the `resolveConfig` hook.
+ */
+export interface ApplicationOverrides {
+    /**
+     * The new application locale.
+     */
+    locale?: string;
 }
 
 /**
@@ -230,7 +247,7 @@ export function createCustomElement(options: CustomElementOptions): ApplicationE
             return this.#instance.whenAPI();
         }
 
-        #triggerReload(overrides?: AppOverrides) {
+        #triggerReload(overrides?: ApplicationOverrides) {
             // Defer the restart operation a tiny bit so calling code does not get surprised by the application's destruction.
             if (this.#deferredRestart) {
                 clearTimeout(this.#deferredRestart);
@@ -248,7 +265,7 @@ export function createCustomElement(options: CustomElementOptions): ApplicationE
             }, 1);
         }
 
-        #createApplicationInstance(overrides?: AppOverrides) {
+        #createApplicationInstance(overrides?: ApplicationOverrides) {
             return new AppInstance({
                 rootNode: this.#shadowRoot ?? document,
                 hostElement: this,

--- a/src/packages/runtime/app/AppInstance.ts
+++ b/src/packages/runtime/app/AppInstance.ts
@@ -20,7 +20,12 @@ import {
     RUNTIME_AUTO_START
 } from "../builtin-services";
 import { ApplicationLifecycleEventService } from "../builtin-services/ApplicationLifecycleEventService";
-import { ApplicationConfig, ApplicationProperties, CustomElementOptions } from "../CustomElement";
+import {
+    ApplicationConfig,
+    ApplicationOverrides,
+    ApplicationProperties,
+    CustomElementOptions
+} from "../CustomElement";
 import { createAppRoot, isShadowRoot, RootNode } from "../dom";
 import { ErrorId } from "../errors";
 import { AppIntl, createPackageIntl, getBrowserLocales, I18nConfig, initI18n } from "../i18n";
@@ -46,17 +51,13 @@ export interface AppOptions {
     elementOptions: CustomElementOptions;
 
     /** These have higher priority than the options in `elementOptions`. */
-    overrides: AppOverrides | undefined;
+    overrides: ApplicationOverrides | undefined;
 
     /**
      * A callback to restart the application with new options.
      * Currently only used for reloading with a certain locale.
      */
-    restart: (overrides?: AppOverrides) => void;
-}
-
-export interface AppOverrides {
-    locale?: string;
+    restart: (overrides?: ApplicationOverrides) => void;
 }
 
 export type AppState = "not-started" | "starting" | "started" | "destroyed" | "error";

--- a/src/packages/runtime/app/gatherConfig.ts
+++ b/src/packages/runtime/app/gatherConfig.ts
@@ -1,9 +1,13 @@
 // SPDX-FileCopyrightText: 2023-2025 Open Pioneer project (https://github.com/open-pioneer)
 // SPDX-License-Identifier: Apache-2.0
 import { Error } from "@open-pioneer/core";
-import { ApplicationConfig, ApplicationProperties, CustomElementOptions } from "../CustomElement";
+import {
+    ApplicationConfig,
+    ApplicationOverrides,
+    ApplicationProperties,
+    CustomElementOptions
+} from "../CustomElement";
 import { ErrorId } from "../errors";
-import { AppOverrides } from "./AppInstance";
 
 /**
  * Gathers application properties by reading them from the options object
@@ -12,7 +16,7 @@ import { AppOverrides } from "./AppInstance";
 export async function gatherConfig(
     hostElement: HTMLElement,
     options: CustomElementOptions,
-    overrides?: AppOverrides
+    overrides?: ApplicationOverrides
 ) {
     let configs: ApplicationConfig[];
     try {
@@ -22,7 +26,8 @@ export async function gatherConfig(
                 hostElement,
                 getAttribute(name) {
                     return hostElement.getAttribute(name) ?? undefined;
-                }
+                },
+                overrides
             })) ?? {};
 
         configs = [staticConfig, dynamicConfig];

--- a/src/packages/runtime/app/index.ts
+++ b/src/packages/runtime/app/index.ts
@@ -1,3 +1,3 @@
 // SPDX-FileCopyrightText: 2023-2025 Open Pioneer project (https://github.com/open-pioneer)
 // SPDX-License-Identifier: Apache-2.0
-export { AppInstance, type AppOptions, type AppOverrides, type AppState } from "./AppInstance";
+export { AppInstance, type AppOptions, type AppState } from "./AppInstance";

--- a/src/packages/runtime/index.ts
+++ b/src/packages/runtime/index.ts
@@ -5,6 +5,7 @@ export { type PackageIntl, type PackageIntlExtensions, type RichTextValue } from
 export {
     type AdvancedCustomElementOptions,
     type ApplicationConfig,
+    type ApplicationOverrides,
     type ApplicationElement,
     type ApplicationElementConstructor,
     type ApplicationProperties,


### PR DESCRIPTION
Overrides are currently being used to restart an application with new locale.
The `overrides` property in `resolveConfig` can now be used to detect such cases:

```ts
const element = createCustomElement({
    component: AppUI,
    appMetadata,
    resolveConfig({ overrides }) {
        console.log(overrides?.locale);
    }
});
```