### PR TITLE
Use earliest possible timing for useEvent

### DIFF
--- a/.changeset/bright-flies-tap.md
+++ b/.changeset/bright-flies-tap.md
@@ -1,0 +1,5 @@
+---
+"@open-pioneer/react-utils": patch
+---
+
+Support calling `useEvent()` callbacks in `useInsertionEffect()` or similar timings. Previously, `useEvent()` only worked correctly when used in `useLayoutEffect()` or later.

--- a/src/packages/react-utils/useEvent.test.ts
+++ b/src/packages/react-utils/useEvent.test.ts
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2023-2025 Open Pioneer project (https://github.com/open-pioneer)
+// SPDX-License-Identifier: Apache-2.0
+import { renderHook } from "@testing-library/react";
+import { expect, it, vi } from "vitest";
+import { useEvent } from "./useEvent";
+import { useInsertionEffect } from "react";
+
+it("provides a stable handler function", () => {
+    const hook = renderHook(
+        (fn: () => number) => {
+            return useEvent(fn);
+        },
+        {
+            initialProps: () => 123
+        }
+    );
+
+    const stableFn = hook.result.current;
+    expect(typeof stableFn).toBe("function");
+    expect(stableFn()).toBe(123);
+
+    hook.rerender(() => 456);
+    expect(hook.result.current).toBe(stableFn);
+    expect(stableFn()).toBe(456);
+});
+
+it("is available in useInsertionEffect", () => {
+    const spy = vi.fn();
+    const _hook = renderHook(
+        (fn: () => void) => {
+            const stableFn = useEvent(fn);
+
+            // Must not throw
+            useInsertionEffect(stableFn);
+        },
+        {
+            initialProps: spy
+        }
+    );
+    expect(spy).toHaveBeenCalled();
+});


### PR DESCRIPTION
Fixes misbehavior of `useEvent` when called very early, e.g. during `useInsertionEffect`. 
