### PR TITLE
[runtime] Add support for configuration of `chakraSystemConfig` in `config` and `resolveConfig`

### DIFF
--- a/.changeset/solid-files-own.md
+++ b/.changeset/solid-files-own.md
@@ -1,0 +1,6 @@
+---
+"@open-pioneer/runtime": minor
+---
+
+createCustomElement: Add support for configuration of `chakraSystemConfig` in `config` and `resolveConfig`.
+This is needed when the specific application theme depends on asynchronous data.

--- a/src/packages/runtime/CustomElement.ts
+++ b/src/packages/runtime/CustomElement.ts
@@ -107,6 +107,15 @@ export interface ApplicationConfig {
      * Properties specified here will override default properties of the application's packages.
      */
     properties?: ApplicationProperties | undefined;
+
+    /**
+     * Chakra styled system object.
+     *
+     * Used to configure chakra's theme.
+     *
+     * NOTE: This setting has priority over {@link CustomElementOptions.chakraSystemConfig}.
+     */
+    chakraSystemConfig?: ChakraSystemConfig;
 }
 
 /**

--- a/src/packages/runtime/app/AppInstance.ts
+++ b/src/packages/runtime/app/AppInstance.ts
@@ -173,6 +173,7 @@ export class AppInstance {
         this.checkAbort();
 
         // Launch react
+        const chakraSystemConfig = config.chakraSystemConfig ?? elementOptions.chakraSystemConfig;
         this.reactIntegration = ReactIntegration.createForApp({
             rootNode: root,
             hostNode: hostElement,
@@ -180,7 +181,7 @@ export class AppInstance {
             serviceLayer,
             packages,
             locale: i18n.locale,
-            config: elementOptions.chakraSystemConfig,
+            config: chakraSystemConfig,
             styles
         });
         const component = this.options.elementOptions.component ?? EmptyComponent;

--- a/src/packages/runtime/app/gatherConfig.ts
+++ b/src/packages/runtime/app/gatherConfig.ts
@@ -17,7 +17,7 @@ export async function gatherConfig(
     hostElement: HTMLElement,
     options: CustomElementOptions,
     overrides?: ApplicationOverrides
-) {
+): Promise<Required<ApplicationConfig>> {
     let configs: ApplicationConfig[];
     try {
         const staticConfig = options.config ?? {};
@@ -57,6 +57,7 @@ function mergeConfigs(configs: ApplicationConfig[]): Required<ApplicationConfig>
     const mergedConfig: Required<ApplicationConfig> = Object.assign(
         {
             locale: undefined,
+            chakraSystemConfig: undefined,
             properties: {}
         } satisfies ApplicationConfig,
         ...configs


### PR DESCRIPTION
Adds support for asynchronous chakra theme configuration, for example:

```ts
const elem = createCustomElement({
    component: ...,
    async resolveConfig() {
        return {
            chakraSystemConfig: myChakraThemeConfig
        };
    }
});
```