### PR TITLE
Feature proposal - support of a service factory pattern

### DIFF
--- a/.changeset/long-wings-create.md
+++ b/.changeset/long-wings-create.md
@@ -1,0 +1,5 @@
+---
+"@open-pioneer/runtime": patch
+---
+
+runtime - introduce support for ServiceFactories, to provide constructor indirection during service creation

--- a/.changeset/long-wings-create.md
+++ b/.changeset/long-wings-create.md
@@ -1,5 +1,5 @@
 ---
-"@open-pioneer/runtime": patch
+"@open-pioneer/runtime": minor
 ---
 
-runtime - introduce support for ServiceFactories, to provide constructor indirection during service creation
+runtime - Introduce support for ServiceFactories, to provide constructor indirection during service creation

--- a/src/packages/runtime/Service.ts
+++ b/src/packages/runtime/Service.ts
@@ -82,3 +82,55 @@ export type ServiceOptions<References extends {} = {}> = {
 export type ServiceConstructor<References extends {} = {}, Interface extends {} = {}> = {
     new (options: ServiceOptions<References>): Service<Interface>;
 };
+
+/**
+ * A service factory is an object that has a method to create a service instance.
+ * The service factory itself can also implement lifecycle hooks, which will be called by the runtime
+ * when the factory is destroyed.
+ */
+export type ServiceFactory<Interface extends {} = {}> = ServiceLifecycleHooks & {
+    /**
+     * Method to create a service instance.
+     * It is directly called by the runtime after constructing the factory
+     */
+    createService(): Service<Interface>;
+};
+
+/**
+ * A constructor type for a service factory.
+ * The service factory is an object that has a method to create a service instance,
+ * this allows for more flexibility in service construction.
+ */
+export type ServiceFactoryConstructor<References extends {} = {}, Interface extends {} = {}> = {
+    new (options: ServiceOptions<References>): ServiceFactory<Interface>;
+};
+
+/**
+ * Symbol used to detect if a constructor function is a service factory constructor.
+ */
+const IS_SERVICE_FACTORY = Symbol("runtime.IS_SERVICE_FACTORY");
+export { IS_SERVICE_FACTORY };
+
+/**
+ * A service factory constructor must be marked
+ * with the `IS_SERVICE_FACTORY` symbol to be recognized by the runtime as such.
+ */
+export type MarkedServiceFactoryConstructor<
+    References extends {} = {},
+    Interface extends {} = {}
+> = ServiceFactoryConstructor<References, Interface> & {
+    [IS_SERVICE_FACTORY]: true;
+};
+
+/**
+ * Utility function to mark a constructor as a service factory constructor.
+ * @param ctr normal constructor function for a service factory.
+ * @returns the same constructor function, but marked with the `IS_SERVICE_FACTORY` symbol so that the runtime recognizes it as a service factory constructor.
+ */
+export function defineServiceFactory(
+    ctr: ServiceFactoryConstructor
+): MarkedServiceFactoryConstructor {
+    const markedCtr = ctr as MarkedServiceFactoryConstructor;
+    markedCtr[IS_SERVICE_FACTORY] = true;
+    return markedCtr;
+}

--- a/src/packages/runtime/Service.ts
+++ b/src/packages/runtime/Service.ts
@@ -94,6 +94,11 @@ export type ServiceFactory<Interface extends {} = {}> = ServiceLifecycleHooks & 
      * It is directly called by the runtime after constructing the factory
      */
     createService(): Service<Interface>;
+    /**
+     * Optional method to destroy a service instance created by this factory.
+     * This is called shortly before the factory itself is destroyed.
+     */
+    destroyService?(service: Service<Interface>): void;
 };
 
 /**

--- a/src/packages/runtime/Service.ts
+++ b/src/packages/runtime/Service.ts
@@ -88,17 +88,19 @@ export type ServiceConstructor<References extends {} = {}, Interface extends {} 
  * The service factory itself can also implement lifecycle hooks, which will be called by the runtime
  * when the factory is destroyed.
  */
-export type ServiceFactory<Interface extends {} = {}> = ServiceLifecycleHooks & {
+export type ServiceFactory<Interface extends {} = {}> = {
     /**
      * Method to create a service instance.
-     * It is directly called by the runtime after constructing the factory
+     * It is directly called by the runtime after constructing the factory.
+     * NOTE: the service.destroy lifecycle hook is not called by the runtime.
      */
-    createService(): Service<Interface>;
+    createService(): Interface;
     /**
      * Optional method to destroy a service instance created by this factory.
-     * This is called shortly before the factory itself is destroyed.
+     * If provided, this method will be called by the runtime when the service instance is destroyed.
+     * A factory instance exists per service, this method invocation means that the factory is no longer used by the runtime.
      */
-    destroyService?(service: Service<Interface>): void;
+    destroyService?(service: Interface): void;
 };
 
 /**

--- a/src/packages/runtime/metadata/index.ts
+++ b/src/packages/runtime/metadata/index.ts
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: 2023-2025 Open Pioneer project (https://github.com/open-pioneer)
 // SPDX-License-Identifier: Apache-2.0
-import { ServiceConstructor } from "../Service";
+import { MarkedServiceFactoryConstructor, ServiceConstructor } from "../Service";
 import { ObservableBox } from "./ObservableBox";
 
 /**
@@ -70,7 +70,7 @@ export interface ServiceMetadata {
 
     /** Service constructor responsible for creating a new instance. */
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    clazz: ServiceConstructor<any>;
+    clazz: ServiceConstructor<any> | MarkedServiceFactoryConstructor<any>;
 
     /**
      * Collection of references to other services.

--- a/src/packages/runtime/service-layer/ServiceLayer.test.ts
+++ b/src/packages/runtime/service-layer/ServiceLayer.test.ts
@@ -288,7 +288,7 @@ it("supports using a service factory to create service instances", function () {
                 }
             };
         }
-        destroyService(service: Service<HelloService>): void {
+        destroyService(_service: Service<HelloService>): void {
             called.push("factory.destroyService");
         }
         destroy(): void {
@@ -338,9 +338,8 @@ it("supports using a service factory to create service instances", function () {
     serviceLayer.destroy();
 
     expect(called).toEqual([
-        //-> Should not be called: "service.destroy",
-        "factory.destroyService",
-        "factory.destroy"
+        //Should not be called by runtime: "service.destroy",
+        "factory.destroyService"
     ]);
 });
 

--- a/src/packages/runtime/service-layer/ServiceLayer.test.ts
+++ b/src/packages/runtime/service-layer/ServiceLayer.test.ts
@@ -268,28 +268,31 @@ it("supports using a function to create service instances", function () {
 });
 
 it("supports using a service factory to create service instances", function () {
-    let called = 0;
+    let called: string[] = [];
 
     type HelloService = { hello(): string };
 
     class HelloServiceFactory implements ServiceFactory<HelloService> {
         constructor(private options: ServiceOptions) {
-            ++called;
+            called.push("factory.constructor");
         }
         createService() {
-            ++called;
+            called.push("factory.createService");
             const opts = this.options;
             return {
                 hello() {
                     return `Hello ${opts.properties.target}!`;
                 },
                 destroy(): void {
-                    called++;
+                    called.push("service.destroy");
                 }
             };
         }
+        destroyService(service: Service<HelloService>): void {
+            called.push("factory.destroyService");
+        }
         destroy(): void {
-            called++;
+            called.push("factory.destroy");
         }
     }
 
@@ -324,16 +327,21 @@ it("supports using a service factory to create service instances", function () {
     );
 
     serviceLayer.start();
-    // one for factory construction, one for service creation
-    expect(called).toBe(2);
+
+    expect(called).toEqual(["factory.constructor", "factory.createService"]);
+    called = [];
 
     const instance = service.getInstanceOrThrow();
     const message = (instance as HelloService).hello();
     expect(message).toEqual("Hello world!");
 
     serviceLayer.destroy();
-    // one for service destroy, one for factory destroy
-    expect(called).toBe(4);
+
+    expect(called).toEqual([
+        //-> Should not be called: "service.destroy",
+        "factory.destroyService",
+        "factory.destroy"
+    ]);
 });
 
 it("injects all implementations of an interface when requested", function () {

--- a/src/packages/runtime/service-layer/ServiceLayer.test.ts
+++ b/src/packages/runtime/service-layer/ServiceLayer.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { describe, expect, it } from "vitest";
 import { createEmptyPackageIntl } from "../i18n";
-import { Service, ServiceOptions } from "../Service";
+import { defineServiceFactory, Service, ServiceFactory, ServiceOptions } from "../Service";
 import { PackageRepr, PackageReprOptions } from "./PackageRepr";
 import { ServiceLayer } from "./ServiceLayer";
 import { Found } from "./ServiceLookup";
@@ -10,6 +10,7 @@ import { ReferenceSpec } from "./InterfaceSpec";
 import {
     createConstructorFactory,
     createFunctionFactory,
+    createFactoryForServiceFactory,
     ServiceRepr,
     ServiceReprOptions
 } from "./ServiceRepr";
@@ -264,6 +265,75 @@ it("supports using a function to create service instances", function () {
     const instance = service.getInstanceOrThrow();
     const message = (instance as HelloService).hello();
     expect(message).toEqual("Hello world!");
+});
+
+it("supports using a service factory to create service instances", function () {
+    let called = 0;
+
+    type HelloService = { hello(): string };
+
+    class HelloServiceFactory implements ServiceFactory<HelloService> {
+        constructor(private options: ServiceOptions) {
+            ++called;
+        }
+        createService() {
+            ++called;
+            const opts = this.options;
+            return {
+                hello() {
+                    return `Hello ${opts.properties.target}!`;
+                },
+                destroy(): void {
+                    called++;
+                }
+            };
+        }
+        destroy(): void {
+            called++;
+        }
+    }
+
+    // Mark the factory with the symbol so that the runtime recognizes it as a service factory constructor
+    const markedFactory = defineServiceFactory(HelloServiceFactory);
+
+    const service = createService({
+        name: "A",
+        packageName: "a",
+        factory: createFactoryForServiceFactory(markedFactory),
+        interfaces: [
+            {
+                interfaceName: "foo"
+            }
+        ],
+        properties: {
+            target: "world"
+        }
+    });
+    const serviceLayer = new ServiceLayer(
+        [
+            createPackage({
+                name: "a",
+                services: [service]
+            })
+        ],
+        [
+            {
+                interfaceName: "foo"
+            }
+        ]
+    );
+
+    serviceLayer.start();
+    // one for factory construction, one for service creation
+    expect(called).toBe(2);
+
+    const instance = service.getInstanceOrThrow();
+    const message = (instance as HelloService).hello();
+    expect(message).toEqual("Hello world!");
+
+    serviceLayer.destroy();
+    // one for service destroy, one for factory destroy
+    expect(called).toBe(4);
 });
 
 it("injects all implementations of an interface when requested", function () {

--- a/src/packages/runtime/service-layer/ServiceRepr.ts
+++ b/src/packages/runtime/service-layer/ServiceRepr.ts
@@ -2,7 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 import { ErrorId } from "../errors";
 import { ServiceMetadata } from "../metadata";
-import { Service, ServiceConstructor, ServiceOptions } from "../Service";
+import {
+    Service,
+    ServiceConstructor,
+    ServiceOptions,
+    IS_SERVICE_FACTORY,
+    ServiceFactory,
+    MarkedServiceFactoryConstructor
+} from "../Service";
 import { Error } from "@open-pioneer/core";
 import { InterfaceSpec, parseReferenceSpec, ReferenceSpec } from "./InterfaceSpec";
 import { PackageIntl } from "../i18n";
@@ -11,23 +18,15 @@ export type ServiceState = "not-constructed" | "constructing" | "constructed" | 
 
 export type ServiceDependency = ReferenceSpec & { referenceName: string };
 
-export interface ConstructorFactory {
-    type: "class";
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    clazz: ServiceConstructor<any>;
+export interface ServiceInstanceFactory {
+    create(options: ServiceOptions): Service;
+    destroy(srv: Service): void;
 }
-
-export interface FunctionFactory {
-    type: "function";
-    create: (options: ServiceOptions) => Service;
-}
-
-export type ServiceFactory = ConstructorFactory | FunctionFactory;
 
 export interface ServiceReprOptions {
     name: string;
     packageName: string;
-    factory: ServiceFactory;
+    factory: ServiceInstanceFactory;
     intl: PackageIntl;
     dependencies?: ServiceDependency[];
     interfaces?: InterfaceSpec[];
@@ -61,10 +60,7 @@ export class ServiceRepr {
                 qualifier: i.qualifier
             };
         });
-        const factory: ConstructorFactory = {
-            type: "class",
-            clazz
-        };
+        const factory = createConstructorFactory(clazz);
         return new ServiceRepr({
             name,
             packageName,
@@ -101,7 +97,7 @@ export class ServiceRepr {
     private _useCount = 0;
 
     /** Service factory to construct an instance. */
-    private factory: ServiceFactory;
+    private factory: ServiceInstanceFactory;
 
     /** Current state of this service. "constructed" -> instance is available. */
     private _state: ServiceState = "not-constructed";
@@ -191,7 +187,7 @@ export class ServiceRepr {
             );
         }
         try {
-            this._instance = createService(this.factory, {
+            this._instance = this.factory.create({
                 ...options,
                 properties: this.properties,
                 intl: this.intl
@@ -211,7 +207,7 @@ export class ServiceRepr {
     destroy() {
         if (this._instance) {
             try {
-                this._instance.destroy?.();
+                this.factory.destroy(this._instance);
             } catch (e) {
                 throw new Error(
                     ErrorId.SERVICE_DESTRUCTION_FAILED,
@@ -242,28 +238,89 @@ export class ServiceRepr {
 }
 
 export function createConstructorFactory<T extends {}>(
-    clazz: ServiceConstructor<T>
-): ConstructorFactory {
-    return { type: "class", clazz };
+    clazz: ServiceConstructor<T> | MarkedServiceFactoryConstructor<T>
+): ServiceInstanceFactory {
+    // check if factory is a service factory constructor (has the IS_SERVICE_FACTORY symbol)
+    if (IS_SERVICE_FACTORY in clazz) {
+        return createFactoryForServiceFactory(clazz);
+    }
+    // Is a regular service constructor
+    return {
+        create(options: ServiceOptions<T>) {
+            return new clazz(options);
+        },
+        destroy(instance: Service<T>) {
+            instance.destroy?.();
+        }
+    };
+}
+
+export function createFactoryForServiceFactory<T extends {}>(
+    facClazz: MarkedServiceFactoryConstructor<T>
+): ServiceInstanceFactory {
+    return new ServiceFactoryInstanceFactory(facClazz);
+}
+
+class ServiceFactoryInstanceFactory<T extends {}> implements ServiceInstanceFactory {
+    private _fac: ServiceFactory | undefined = undefined;
+
+    constructor(private _facClazz: MarkedServiceFactoryConstructor<T>) {}
+
+    create(options: ServiceOptions<T>) {
+        const fac = new this._facClazz(options);
+        try {
+            const instance = fac.createService();
+            this._fac = fac;
+            return instance;
+        } catch (e) {
+            try {
+                fac.destroy?.();
+            } catch (_destroyError) {
+                // ignore errors from destroy,
+                // as the main error is more relevant
+                // and the factory might be in an inconsistent state already
+            }
+            throw e;
+        }
+    }
+
+    destroy(srv: Service) {
+        let _srvError: unknown;
+        try {
+            srv.destroy?.();
+        } catch (e) {
+            _srvError = e;
+        }
+        if (this._fac) {
+            try {
+                this._fac.destroy?.();
+            } catch (e) {
+                if (!_srvError) {
+                    throw e;
+                }
+            } finally {
+                this._fac = undefined;
+            }
+        }
+        if (_srvError) {
+            throw _srvError;
+        }
+    }
 }
 
 export function createFunctionFactory(
     create: (options: ServiceOptions) => Service
-): FunctionFactory {
-    return { type: "function", create };
+): ServiceInstanceFactory {
+    return {
+        create,
+        destroy(srv) {
+            srv.destroy?.();
+        }
+    };
 }
 
 const SERVICE_NAME_REGEX = /^[a-z0-9_-]+$/i;
 
 function isValidServiceName(name: string) {
     return SERVICE_NAME_REGEX.test(name);
-}
-
-function createService(factory: ServiceFactory, options: ServiceOptions) {
-    switch (factory.type) {
-        case "class":
-            return new factory.clazz(options);
-        case "function":
-            return factory.create(options);
-    }
 }

--- a/src/packages/runtime/service-layer/ServiceRepr.ts
+++ b/src/packages/runtime/service-layer/ServiceRepr.ts
@@ -289,31 +289,35 @@ class ServiceFactoryInstanceFactory<T extends {}> implements ServiceInstanceFact
     }
 
     destroy(srv: Service) {
-        let _srvError: unknown;
+        if (!this._fac) {
+            throw new Error(
+                ErrorId.INTERNAL,
+                "Inconsistent state: service factory instance is not present."
+            );
+        }
+        let srvDestroyError: unknown;
         try {
-            srv.destroy?.();
+            this._fac.destroyService?.(srv);
         } catch (e) {
-            _srvError = e;
+            srvDestroyError = e;
         }
-        if (this._fac) {
-            try {
-                this._fac.destroy?.();
-            } catch (facDestroyError) {
-                if (!_srvError) {
-                    throw facDestroyError;
-                } else {
-                    // TODO: drop the log, and throw a SuppressedError, if suppressed errors are commonly supported in browsers
-                    LOG.error(
-                        `Failed to destroy service factory after failed service destruction:`,
-                        facDestroyError
-                    );
-                }
-            } finally {
-                this._fac = undefined;
+        try {
+            this._fac.destroy?.();
+        } catch (facDestroyError) {
+            if (!srvDestroyError) {
+                throw facDestroyError;
+            } else {
+                // TODO: drop the log, and throw a SuppressedError, if suppressed errors are commonly supported in browsers
+                LOG.error(
+                    `Failed to destroy service factory after failed service destruction:`,
+                    facDestroyError
+                );
             }
+        } finally {
+            this._fac = undefined;
         }
-        if (_srvError) {
-            throw _srvError;
+        if (srvDestroyError) {
+            throw srvDestroyError;
         }
     }
 }

--- a/src/packages/runtime/service-layer/ServiceRepr.ts
+++ b/src/packages/runtime/service-layer/ServiceRepr.ts
@@ -10,11 +10,9 @@ import {
     ServiceFactory,
     MarkedServiceFactoryConstructor
 } from "../Service";
-import { createLogger, Error } from "@open-pioneer/core";
+import { Error } from "@open-pioneer/core";
 import { InterfaceSpec, parseReferenceSpec, ReferenceSpec } from "./InterfaceSpec";
 import { PackageIntl } from "../i18n";
-import { sourceId } from "open-pioneer:source-info";
-const LOG = createLogger(sourceId);
 
 export type ServiceState = "not-constructed" | "constructing" | "constructed" | "destroyed";
 
@@ -270,22 +268,9 @@ class ServiceFactoryInstanceFactory<T extends {}> implements ServiceInstanceFact
 
     create(options: ServiceOptions<T>) {
         const fac = new this._facClazz(options);
-        try {
-            const instance = fac.createService();
-            this._fac = fac;
-            return instance;
-        } catch (e) {
-            try {
-                fac.destroy?.();
-            } catch (facDestroyError) {
-                // TODO: drop the log, and throw a SuppressedError, if suppressed errors are commonly supported in browsers
-                LOG.error(
-                    `Failed to destroy service factory after failed service creation:`,
-                    facDestroyError
-                );
-            }
-            throw e;
-        }
+        const instance = fac.createService();
+        this._fac = fac;
+        return instance;
     }
 
     destroy(srv: Service) {
@@ -295,29 +280,10 @@ class ServiceFactoryInstanceFactory<T extends {}> implements ServiceInstanceFact
                 "Inconsistent state: service factory instance is not present."
             );
         }
-        let srvDestroyError: unknown;
         try {
             this._fac.destroyService?.(srv);
-        } catch (e) {
-            srvDestroyError = e;
-        }
-        try {
-            this._fac.destroy?.();
-        } catch (facDestroyError) {
-            if (!srvDestroyError) {
-                throw facDestroyError;
-            } else {
-                // TODO: drop the log, and throw a SuppressedError, if suppressed errors are commonly supported in browsers
-                LOG.error(
-                    `Failed to destroy service factory after failed service destruction:`,
-                    facDestroyError
-                );
-            }
         } finally {
             this._fac = undefined;
-        }
-        if (srvDestroyError) {
-            throw srvDestroyError;
         }
     }
 }


### PR DESCRIPTION
This is a proposal to support factories for service creation.
----

## Why?

Currently a service can only be created as a single class, like:

```ts
interface MyService extends DeclaredService<"my">{
   serviceMethod(): void
}

class MyServiceImpl implements MyService {
   constructor(options: ServiceOptions){
      ....
   }
   serviceMethod(): void  {}
}
``` 

This makes it hard to adapt e.g. existing classes as services.
Also every service implementation is very tight coupled to this way of construction and to the ServiceOptions type.

## Factory approach

The proposal introduces a way of indirection between Service construction and Service implementation, by a factory pattern.

```ts
interface MyService extends DeclaredService<"my">{
   serviceMethod(): void
}

interface MyServiceConstructorOptions {
  // what ever properties you need
}

class MyServiceImpl implements MyService {
   constructor(options: MyServiceConstructorOptions ){
      ....
   }
   serviceMethod(): void  {}
}

class MyServiceFactoryImpl implements ServiceFactory<MyService> {
   constructor(options: ServiceOptions){
   }
   createService(){
          // create the service the way you like
          const myServ = new MyService({...});
          return myServ;
   }
}

// need to mark the factory, to let the runtime detect that it is a factory.
export const MyServiceFactory = defineServiceFactory(MyServiceFactoryImpl );
```

This factory pattern, does not break the service metadata, still a class is registered.

I used the approach of marking the Factory constructor with a symbol.
This is done by the helper  `defineServiceFactory`.
Using this approach the runtime can clear detect that the class is a factory and not a "normal" service class.

The decision that a ServiceFactory is used is made by a developer in the implementation file and not transported by any other metadata.
The service metadata in the build-config is unchanged.

Please consider the test case `supports using a service factory to create service instances` in the `ServiceLayer.test.ts` for an example.

What do you think?