### PR TITLE
Feature  - add 'initUiServicesOnDemand' feature toggle 

### DIFF
--- a/.changeset/brave-flowers-buy.md
+++ b/.changeset/brave-flowers-buy.md
@@ -1,0 +1,5 @@
+---
+"@open-pioneer/runtime": minor
+---
+
+runtime - introduce feature toggle 'initUiServicesOnDemand' to defer any service used by the ui layer to be initiated on first access

--- a/src/packages/runtime/app/AppInstance.ts
+++ b/src/packages/runtime/app/AppInstance.ts
@@ -347,7 +347,11 @@ function createServiceLayer(config: {
             all: true
         }
     ];
-    const serviceLayer = new ServiceLayer(packages, forcedReferences);
+    const initUiServicesOnDemand =
+        config.properties[builtinPackage.name]?.initUiServicesOnDemand === true;
+    const serviceLayer = new ServiceLayer(packages, forcedReferences, {
+        initUiServicesOnDemand
+    });
     return {
         packages: new Map(packages.map((pkg) => [pkg.name, pkg])),
         serviceLayer: serviceLayer

--- a/src/packages/runtime/build.config.mjs
+++ b/src/packages/runtime/build.config.mjs
@@ -11,5 +11,13 @@ export default defineBuildConfig({
         "react-integration/index",
         // Needed for @open-pioneer/test-utils
         "test-support/index"
-    ]
+    ],
+    properties: {
+        initUiServicesOnDemand: false
+    },
+    propertiesMeta: {
+        initUiServicesOnDemand: {
+            required: false
+        }
+    }
 });


### PR DESCRIPTION
This pull request provides an new feature toggle 'initUiServicesOnDemand'.
If this toggle is enabled, any service only used by the ui layer is created with the first access of the ui to it (on demand).

To enable the feature toggle use following application property:

```ts
const Element = createCustomElement({
    component: AppUI,
    appMetadata,
    config: {
        properties: {
            "@open-pioneer/runtime": {
                initUiServicesOnDemand: true
            }
        }
    }
});
```

The toggle is designed as an opt in for situations where fine grained start optimization is required.
This may happen if an application uses many services but only on separated views.
