### PR TITLE
Feature - do not wait for api service initialization during app start

### DIFF
--- a/.changeset/bright-toes-refuse.md
+++ b/.changeset/bright-toes-refuse.md
@@ -2,4 +2,4 @@
 "@open-pioneer/runtime": minor
 ---
 
-runtime - api initialization does not longer block app start
+API initialization does no longer block rendering of the user interface.

--- a/src/packages/runtime/app/AppInstance.ts
+++ b/src/packages/runtime/app/AppInstance.ts
@@ -274,7 +274,6 @@ export class AppInstance {
             LOG.debug("Application API initialized to", api);
             this.apiPromise?.resolve(api);
         } catch (e) {
-            LOG.error("Failed to gather the application's API methods.", e);
             const ex = new Error(
                 ErrorId.INTERNAL,
                 "Failed to gather the application's API methods.",

--- a/src/samples/api-sample/index.html
+++ b/src/samples/api-sample/index.html
@@ -16,12 +16,17 @@
 
         customElements.whenDefined("api-app").then(() => {
             const app = document.getElementById("app");
-            app.when().then((api) => {
-                let count = 0;
-                setInterval(() => {
-                    api.changeText(`Text has been changed ${++count} times.`);
-                }, 1000);
-            });
+            app.when().then(
+                (api) => {
+                    let count = 0;
+                    setInterval(() => {
+                        api.changeText(`Text has been changed ${++count} times.`);
+                    }, 1000);
+                },
+                (error) => {
+                    console.error("App did not initialize", error);
+                }
+            );
         });
     </script>
 </html>


### PR DESCRIPTION
I' m not sure if the old behavior was a feature before?

The application startup was blocked until an custom API service provides an API instance.

My change lets the AppInstance not longer wait for the API initialization, so the AppUI is displayed directly.

If an error occurs in the API initialization it is now reported to the apiPromise, if it was created.
The draw back is that a potential API initialization error will not be recognized as full application error.
On the other hand such error handling can now be customized by API consumers (clients waiting for the API on the `when` method.