### PR TITLE
[chakra-snippets] Fix focus issue for disabled tooltip

### DIFF
--- a/src/packages/chakra-snippets/tooltip.tsx
+++ b/src/packages/chakra-snippets/tooltip.tsx
@@ -25,11 +25,12 @@ export const Tooltip = React.forwardRef<HTMLDivElement, TooltipProps>(
       ...rest
     } = props
 
-    if (disabled) return children
+    // PATCH: no early return
+    // if (disabled) return children
 
     return (
-      //PATCH apply open delay
-      <ChakraTooltip.Root openDelay={openDelay} {...rest}>
+      //PATCH apply open delay, apply disabled prop
+      <ChakraTooltip.Root openDelay={openDelay} disabled={disabled} {...rest}>
         <ChakraTooltip.Trigger asChild>{children}</ChakraTooltip.Trigger>
         <Portal disabled={!portalled} container={portalRef}>
           <ChakraTooltip.Positioner>

--- a/src/samples/chakra-showcase/ui/components/ButtonWithOptionalTooltip.tsx
+++ b/src/samples/chakra-showcase/ui/components/ButtonWithOptionalTooltip.tsx
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2023-2025 Open Pioneer project (https://github.com/open-pioneer)
+// SPDX-License-Identifier: Apache-2.0
+import { Button } from "@chakra-ui/react";
+import { Tooltip } from "@open-pioneer/chakra-snippets/tooltip";
+import { useState } from "react";
+import { LuChevronLeft, LuChevronRight } from "react-icons/lu";
+
+export function ButtonWithOptionalTooltip() {
+    const [expanded, setExpanded] = useState(false);
+    const text =
+        "This button has a tooltip when collapsed, and none if expanded. " +
+        'The button should not lose focus when pressing "Enter".';
+
+    return (
+        <Tooltip content={expanded ? null : text} disabled={expanded}>
+            <Button onClick={() => setExpanded((prev) => !prev)}>
+                {expanded ? (
+                    <>
+                        <LuChevronLeft />
+                        Expand
+                    </>
+                ) : (
+                    <LuChevronRight />
+                )}
+            </Button>
+        </Tooltip>
+    );
+}

--- a/src/samples/chakra-showcase/ui/components/ButtonWithOptionalTooltip.tsx
+++ b/src/samples/chakra-showcase/ui/components/ButtonWithOptionalTooltip.tsx
@@ -12,7 +12,7 @@ export function ButtonWithOptionalTooltip() {
         'The button should not lose focus when pressing "Enter".';
 
     return (
-        <Tooltip content={expanded ? null : text} disabled={expanded}>
+        <Tooltip content={text} disabled={expanded}>
             <Button onClick={() => setExpanded((prev) => !prev)}>
                 {expanded ? (
                     <>

--- a/src/samples/chakra-showcase/ui/sections/Buttons.tsx
+++ b/src/samples/chakra-showcase/ui/sections/Buttons.tsx
@@ -13,6 +13,7 @@ import {
 } from "@chakra-ui/react";
 import { LuSearch } from "react-icons/lu";
 import { Presenter } from "../components/Presenter";
+import { ButtonWithOptionalTooltip } from "../components/ButtonWithOptionalTooltip";
 
 export function Buttons() {
     const data = "The quick brown fox jumps over the lazy dog";
@@ -48,6 +49,7 @@ export function Buttons() {
                         <Button loading loadingText="loading...">
                             loading with text
                         </Button>
+                        <ButtonWithOptionalTooltip />
                     </HStack>
                 </VStack>
             </Presenter>


### PR DESCRIPTION
Fix keyboard focus when a button is sometimes surrounded with a tooltip and sometimes not.
Previously the button would lose focus when pressing the Enter key:

```tsx
<Tooltip
    content={/* ... */}
    disabled={expanded} // enabled/disabled based on dynamic condition
>
    <Button onClick={toggleExpanded}>...</Button>
</Tooltip>
```

--- 

This was caused by an early return in the tooltip snippet when `disabled` is `true`. This changed the react node structure, causing the button to be re-mounted (and losing focus in the process). It looks like chakra's `Tooltip.Root` can handle this by itself, too. 
