### PR TITLE
Allow usage of useHeadingLevel hook outside TitledSection

### DIFF
--- a/.changeset/wicked-glasses-wish.md
+++ b/.changeset/wicked-glasses-wish.md
@@ -1,0 +1,22 @@
+---
+"@open-pioneer/react-utils": minor
+---
+
+# Description
+
+Added an `required` option to `useHeadingLevel` hook to make it return `undefined` instead of throwing an error when used outside of a `TitledSection`.
+
+This allows to use the hook in components which do not necessarily need to be used inside a `TitledSection`, while still providing the option to enforce that usage when desired.
+
+Example usage:
+
+```tsx
+const MyComponent = () => {
+    const currentHeading: number | undefined = useHeadingLevel({ required: false });
+    if (currentHeading === undefined) {
+        return <span>No heading level</span>;
+    }
+    const currentHeadingText = `Current heading is ${currentHeading}`;
+    return <span>{currentHeadingText}</span>;
+};
+```

--- a/src/packages/react-utils/TitledSection.test.tsx
+++ b/src/packages/react-utils/TitledSection.test.tsx
@@ -2,7 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 import { render } from "@testing-library/react";
 import { expect, it } from "vitest";
-import { ConfigureTitledSection, SectionHeading, TitledSection } from "./TitledSection";
+import {
+    ConfigureTitledSection,
+    SectionHeading,
+    TitledSection,
+    useHeadingLevel
+} from "./TitledSection";
 import { ReactNode, useEffect, useRef } from "react";
 import { PackageContextProvider } from "@open-pioneer/test-utils/react";
 
@@ -308,6 +313,41 @@ it("supports 'ref' prop on SectionHeading", async () => {
         </TitledSection>
     );
     expect(value!.tagName).toBe("H1");
+});
+
+it("returns headingLevel undefined when used outside a TitledSection and required is false", () => {
+    function Component() {
+        const currentHeading = useHeadingLevel({ required: false });
+        const currentHeadingText = `Current heading is ${currentHeading}`;
+        return <span>{currentHeadingText}</span>;
+    }
+
+    const content = renderContent(<Component />);
+    expect(content.textContent).toBe("Current heading is undefined");
+});
+
+it("throws when using useHeadingLevel outside a TitledSection and required is true", async () => {
+    function Component() {
+        const currentHeading = useHeadingLevel({ required: true });
+        const currentHeadingText = `Current heading is ${currentHeading}`;
+        return <span>{currentHeadingText}</span>;
+    }
+
+    expect(() => renderContent(<Component />)).toThrow(
+        "useHeadingLevel() must be used within a <TitledSection />"
+    );
+});
+
+it("throws when using useHeadingLevel outside a TitledSection", async () => {
+    function Component() {
+        const currentHeading = useHeadingLevel();
+        const currentHeadingText = `Current heading is ${currentHeading}`;
+        return <span>{currentHeadingText}</span>;
+    }
+
+    expect(() => renderContent(<Component />)).toThrow(
+        "useHeadingLevel() must be used within a <TitledSection />"
+    );
 });
 
 function renderContent(children: ReactNode): HTMLElement {

--- a/src/packages/react-utils/TitledSection.tsx
+++ b/src/packages/react-utils/TitledSection.tsx
@@ -212,12 +212,20 @@ export type HeadingLevel = 1 | 2 | 3 | 4 | 5 | 6;
  * Returns the current heading level.
  *
  * This hook should be used in the `title` property of a {@link TitledSection} or in that component's children.
+ * If you use it outside of a TitledSection, it will throw an error by default.
+ * You can set `required: false` to make it return `undefined` instead of throwing an error
  *
  * @group Headings
  */
-export function useHeadingLevel(): HeadingLevel {
+export function useHeadingLevel(): HeadingLevel;
+export function useHeadingLevel(props: { required: false }): HeadingLevel | undefined;
+export function useHeadingLevel(props: { required?: true }): HeadingLevel;
+export function useHeadingLevel(props?: { required?: boolean }): HeadingLevel | undefined {
     const level = useContext(LevelContext);
     if (level == null) {
+        if (props?.required === false) {
+            return undefined;
+        }
         throw new Error("useHeadingLevel() must be used within a <TitledSection />");
     }
     return Math.max(1, Math.min(level, 6)) as HeadingLevel;


### PR DESCRIPTION
Added an `required` option to `useHeadingLevel` hook to make it return `undefined` instead of throwing an error when used outside of a `TitledSection`.

This allows to use the hook in components which do not necessarily need to be used inside a `TitledSection`, while still providing the option to enforce that usage when desired.

Example usage:

```tsx
const MyComponent = () => {
    const currentHeading: number | undefined = useHeadingLevel({ required: false });
    if (currentHeading === undefined) {
        return <span>No heading level</span>;
    }
    const currentHeadingText = `Current heading is ${currentHeading}`;
    return <span>{currentHeadingText}</span>;
};
```